### PR TITLE
[metismenu-frontend] Add back space before $class_sfx

### DIFF
--- a/templates/cassiopeia/html/mod_menu/metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/metismenu.php
@@ -19,7 +19,7 @@ $wa->registerAndUseScript('metismenu', 'mm-horizontal.js', [], [], ['metismenujs
 
 $ulAttribs = [
 		'id'    => $params->get('tag_id', ''),
-		'class' => 'mod-menu mod-menu_metismenu metismenu' . $class_sfx . ' mod-list'
+		'class' => 'mod-menu mod-menu_metismenu metismenu mod-list ' . $class_sfx
 ];
 
 // The menu class is deprecated. Use mod-menu instead


### PR DESCRIPTION
### Summary of Changes

Adapt metismenu to https://github.com/joomla/joomla-cms/pull/30341 for the core menu.

The menu class suffix is a menu class on J4, not a suffix.

See https://github.com/joomla/joomla-cms/pull/17026 for the initial change and https://github.com/joomla/joomla-cms/pull/30341 for the recent fix because it had been broken by https://github.com/joomla/joomla-cms/pull/20702 .