### PR TITLE
[Google Fonts] Use folder and not files in build script for better extensibility

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -44,8 +44,6 @@ module.exports.compile = (options, path) => {
           `${RootPath}/templates/cassiopeia/scss/offline.scss`,
           `${RootPath}/templates/cassiopeia/scss/template.scss`,
           `${RootPath}/templates/cassiopeia/scss/template-rtl.scss`,
-          `${RootPath}/templates/cassiopeia/scss/fonts/josefin-sans.scss`,
-          `${RootPath}/templates/cassiopeia/scss/fonts/montserrat.scss`,
           `${RootPath}/templates/cassiopeia/scss/system/searchtools/searchtools.scss`,
           `${RootPath}/templates/cassiopeia/scss/vendor/choicesjs/choices.scss`,
           `${RootPath}/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss`,
@@ -64,6 +62,7 @@ module.exports.compile = (options, path) => {
 
         folders = [
           `${RootPath}/build/media_source`,
+          `${RootPath}/templates/cassiopeia/scss/fonts`,
         ];
       }
 


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/cassiopeia/pull/18](https://github.com/joomla/cassiopeia/pull/18).

### Summary of Changes

Use the folder and not the files for the css compile script so it is enough to add new scss files for new fonts and doesn't need to modify the script anymore.

### Testing Instructions

Checkout the 4.0-dev-google-fonts-enhancements branch and apply the changes of this PR.

If you have compiled the scss before, remove any css files from the `templates/cassiopeia/css/fonts` folder.

Run `npm ci`.

Check that the compiled css files for the fonts are created in folder `templates/cassiopeia/css/fonts` from the scss files in folder `templates/cassiopeia/scss/fonts`.

What should also be tested (I haven't tested that yet and don't have the time now):

If someone who doesn't want to use scss but css puts a new css file into folder `templates/cassiopeia/css/fonts` folder, will it be deleted when running `npm ci` or `npm run build:css`?

### Documentation Changes Required

