### PR TITLE
Feature cassiopeia/4.0 dev colors as hsl

### DIFF
--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -73,7 +73,7 @@ $theme-colors: (
 );
 
 // Toolbar
-$cassiopeia-toolbar-line-height:         1.8rem;
+$cassiopeia-toolbar-line-height:     1.8rem;
 
 // Fonts
 $cassiopeia-inverted-text-color:     $cassiopeia-template-color;
@@ -88,95 +88,95 @@ $font-size-sm:                       .8rem;
 $fa-font-path:                       "../../../media/vendor/fontawesome-free/webfonts";
 
 // Border Radius
-$border-radius:               .25rem !default;
-$border-radius-lg:            .3rem !default;
-$border-radius-sm:            .2rem !default;
+$border-radius:                      .25rem !default;
+$border-radius-lg:                   .3rem !default;
+$border-radius-sm:                   .2rem !default;
 
 // Tables
-$table-bg:                           transparent !default;
-$table-bg-accent:                    rgba(0,0,0,.03) !default;
+$table-bg:                            transparent !default;
+$table-bg-accent:                     hsla(0, 0%, 0%, 0.03) !default;
 
 // Tabs
-$cassiopeia-tabs-header-bg:              $cassiopeia-block-header-bg;
-$cassiopeia-tabs-active-bg:              rgba(0,0,0,.03);
-$cassiopeia-tabs-active-highlight:       theme-color("primary");
+$cassiopeia-tabs-header-bg:           $cassiopeia-block-header-bg;
+$cassiopeia-tabs-active-bg:           hsla(0, 0%, 0%, 0.03);
+$cassiopeia-tabs-active-highlight:    theme-color("primary");
 
 // Cards
-$cassiopeia-card-title-bg:               $cassiopeia-block-header-bg;
-$cassiopeia-card-title-icon-bg:          $cassiopeia-block-header-bg;
-$cassiopeia-card-title-icon-bg-hover:    darken($cassiopeia-card-title-bg, 2%);
-$card-bg-color-light:                #f8f8f8;
-$card-bg-color-dark:                 $cassiopeia-template-color;
-$card-border-color:                  $cassiopeia-border-color;
+$cassiopeia-card-title-bg:            $cassiopeia-block-header-bg;
+$cassiopeia-card-title-icon-bg:       $cassiopeia-block-header-bg;
+$cassiopeia-card-title-icon-bg-hover: darken($cassiopeia-card-title-bg, 2%);
+$card-bg-color-light:                 hsl(0, 0%, 97%);
+$card-bg-color-dark:                  $cassiopeia-template-color;
+$card-border-color:                   $cassiopeia-border-color;
 
 // Alerts
-$state-success-text:                 $white !default;
-$state-success-bg:                   theme-color("success") !default;
-$state-success-border:               darken(theme-color("success"), 5%) !default;
+$state-success-text:                  $white !default;
+$state-success-bg:                    theme-color("success") !default;
+$state-success-border:                darken(theme-color("success"), 5%) !default;
 
-$state-info-text:                    $white !default;
-$state-info-bg:                      theme-color("info") !default;
-$state-info-border:                  darken(theme-color("info"), 7%) !default;
+$state-info-text:                     $white !default;
+$state-info-bg:                       theme-color("info") !default;
+$state-info-border:                   darken(theme-color("info"), 7%) !default;
 
-$state-warning-text:                 $white !default;
-$state-warning-bg:                   theme-color("warning") !default;
-$state-warning-border:               darken(theme-color("warning"), 5%) !default;
+$state-warning-text:                  $white !default;
+$state-warning-bg:                    theme-color("warning") !default;
+$state-warning-border:                darken(theme-color("warning"), 5%) !default;
 
-$state-danger-text:                  $white !default;
-$state-danger-bg:                    theme-color("danger") !default;
-$state-danger-border:                darken(theme-color("danger"), 5%) !default;
+$state-danger-text:                   $white !default;
+$state-danger-bg:                     theme-color("danger") !default;
+$state-danger-border:                 darken(theme-color("danger"), 5%) !default;
 
 // Treeselect
-$treeselect-line-height:             2.2rem;
+$treeselect-line-height:              2.2rem;
 
 // List
-$list-group-bg:                      $white-offset;
+$list-group-bg:                       $white;
 
 // Custom form
-$custom-select-bg:                   $gray-200;
+$custom-select-bg:                    $gray-200;
 
 // Custom form
-$custom-select-indicator-padding:    3rem;
-$custom-select-bg-size:              116rem;
-$custom-select-indicator:            url("../images/select-bg.svg");
-$custom-select-indicator-rtl:        url("../images/select-bg-rtl.svg");
-$custom-select-indicator-active:     url("../../../images/select-bg.svg");
-$custom-select-indicator-active-rtl: url("../../../images/select-bg-rtl.svg");
-$custom-select-background:           $custom-select-indicator no-repeat right center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
-$custom-select-background-rtl:       $custom-select-indicator-rtl no-repeat left center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
-$custom-select-bg-size-sm:           75rem;
-$custom-select-multiple-padding-y:   .3rem;
+$custom-select-indicator-padding:     3rem;
+$custom-select-bg-size:               116rem;
+$custom-select-indicator:             url("../images/select-bg.svg");
+$custom-select-indicator-rtl:         url("../images/select-bg-rtl.svg");
+$custom-select-indicator-active:      url("../../../images/select-bg.svg");
+$custom-select-indicator-active-rtl:  url("../../../images/select-bg-rtl.svg");
+$custom-select-background:            $custom-select-indicator no-repeat right center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
+$custom-select-background-rtl:        $custom-select-indicator-rtl no-repeat left center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
+$custom-select-bg-size-sm:            75rem;
+$custom-select-multiple-padding-y:    .3rem;
 
 //input
-$input-padding:                    .6rem 1rem;
-$input-border:                     solid 1px  #6d7784;
-$input-btn-padding-y:              .6rem;
-$input-btn-padding-x:              1rem;
+$input-padding:                       .6rem 1rem;
+$input-border:                        solid 1px  hsl(214, 10%, 47%);
+$input-btn-padding-y:                 .6rem;
+$input-btn-padding-x:                 1rem;
 
 // Modals
-$modal-header-height:                46px;
+$modal-header-height:                 46px;
 
 // Badges
-$badge-default-bg:                   #5e7082;
+$badge-default-bg:                    hsl(210, 16%, 44%);
 
 // Gutter
-$grid-gutter-width:                  15px !default;
-$cassiopeia-grid-gutter:             $grid-gutter-width;
+$grid-gutter-width:                   15px !default;
+$cassiopeia-grid-gutter:              $grid-gutter-width;
 
 // Z-Index list
-$zindex-negative:                  -1;
-$zindex-actions:                   auto;
-$zindex-toolbar:                   1000;
-$zindex-sidebar:                   1010;
-$zindex-header:                    1020;
-$zindex-alerts:                    1030;
-$zindex-modal-backdrop:            1040;
-$zindex-modal:                     1050;
-$zindex-popover:                   1060;
-$zindex-tooltip:                   1070;
-$zindex-mobile-bottom:             8000;
-$zindex-mobile-toggle:             9999;
-$zindex-mobile-menu:               9000;
+$zindex-negative:                     -1;
+$zindex-actions:                      auto;
+$zindex-toolbar:                      1000;
+$zindex-sidebar:                      1010;
+$zindex-header:                       1020;
+$zindex-alerts:                       1030;
+$zindex-modal-backdrop:               1040;
+$zindex-modal:                        1050;
+$zindex-popover:                      1060;
+$zindex-tooltip:                      1070;
+$zindex-mobile-bottom:                8000;
+$zindex-mobile-toggle:                9999;
+$zindex-mobile-menu:                  9000;
 
 // MetisMenu
-$metismenu:                        true !default;
+$metismenu:                           true !default;

--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -1,7 +1,6 @@
 @import "../../../media/vendor/bootstrap/scss/functions";
 
 // Global
-$white-offset:                       #fefefe;
 $cassiopeia-template-color-dark:     hsl(220, 67%, 20%) !default;
 $cassiopeia-template-color:          hsl(242, 30%, 36%) !default;
 $cassiopeia-container-main-bg:       hsl(0, 0%, 95%) !default;

--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -1,27 +1,27 @@
 @import "../../../media/vendor/bootstrap/scss/functions";
 
 // Global
-$cassiopeia-template-color-dark:     #112856 !default;
-$cassiopeia-template-color:          #434178 !default;
-$cassiopeia-container-main-bg:       #f2f2f2 !default;
-$cassiopeia-border-color:            #dee2e6 !default;
-$cassiopeia-box-shadow:              0 0 3px rgba(0,0,0,.04) !default;
-$cassiopeia-block-header-bg:         #f5f5f5 !default;
 $white-offset:                       #fefefe;
+$cassiopeia-template-color-dark:     hsl(220, 67%, 20%) !default;
+$cassiopeia-template-color:          hsl(242, 30%, 36%) !default;
+$cassiopeia-container-main-bg:       hsl(0, 0%, 95%) !default;
+$cassiopeia-border-color:            hsl(210, 14%, 89%) !default;
+$cassiopeia-box-shadow:              0 0 3px hsla(0, 0%, 0%, 0.04) !default;
+$cassiopeia-block-header-bg:         hsl(0, 0%, 96%) !default;
 $cassiopeia-header-grad:             linear-gradient(135deg, $cassiopeia-template-color-dark 0%, $cassiopeia-template-color 100%);
 $input-max-width:                    100%;
 
-$white:                              #fff;
-$gray-100:                           #f8f9fa;
-$gray-200:                           #e9ecef;
-$gray-300:                           #dee2e6;
-$gray-400:                           #ced4da;
-$gray-500:                           #adb5bd;
-$gray-600:                           #6c757d;
-$gray-700:                           #495057;
-$gray-800:                           #343a40;
-$gray-900:                           #212529;
-$black:                              #000;
+$white:                              hsl(0, 0%, 100%);
+$gray-100:                           hsl(210, 17%, 98%);
+$gray-200:                           hsl(210, 16%, 93%);
+$gray-300:                           hsl(210, 14%, 89%);
+$gray-400:                           hsl(210, 14%, 83%);
+$gray-500:                           hsl(210, 11%, 71%);
+$gray-600:                           hsl(208, 7%, 46%);
+$gray-700:                           hsl(210, 9%, 31%);
+$gray-800:                           hsl(210, 10%, 23%);
+$gray-900:                           hsl(210, 11%, 15%);
+$black:                              hsl(0, 0%, 0%);
 
 $grays: (
   100: $gray-100,
@@ -36,15 +36,15 @@ $grays: (
 );
 
 $blue:                               $cassiopeia-template-color-dark;
-$indigo:                             #6610f2;
-$purple:                             #6f42c1;
-$pink:                               #e83e8c;
-$red:                                #d9534f;
-$orange:                             #fd7e14;
-$yellow:                             #f0ad4e;
-$green:                              #438243;
-$teal:                               #5bc0de;
-$cyan:                               #108193;
+$indigo:                             hsl(263, 90%, 51%);
+$purple:                             hsl(261, 51%, 51%);
+$pink:                               hsl(332, 79%, 58%);
+$red:                                hsl(2, 64%, 58%);
+$orange:                             hsl(27, 98%, 54%);
+$yellow:                             hsl(35, 84%, 62%);
+$green:                              hsl(120, 32%, 39%);
+$teal:                               hsl(194, 66%, 61%);
+$cyan:                               hsl(188, 80%, 32%);
 
 $colors: (
   blue: $blue,

--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -1,7 +1,7 @@
 // Banner
 
 .container-banner {
-  color: #fff;
+  color: $white;
 
   img {
     display: block;
@@ -20,8 +20,8 @@
       align-items: center;
       justify-content: center;
       height: 100%;
-      color: #fff;
-      background-color: rgba(0,0,0,.5);
+      color: $white;
+      background-color: hsla(0, 0%, 0%, .5);
 
       h2 {
         font-size: 3rem;

--- a/templates/cassiopeia/scss/blocks/_demo-styling.scss
+++ b/templates/cassiopeia/scss/blocks/_demo-styling.scss
@@ -1,6 +1,6 @@
 // Demo Styling
 
-$inverted-color: rgba(255, 255, 255, .9);
+$inverted-color: hsla(0, 0%, 100%, .9);
 
 .demo-module {
   text-align: center;

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -2,11 +2,11 @@
 
 .footer {
   padding: 2.5rem ($cassiopeia-grid-gutter / 2);
-  color: #fff;
+  color: $white;
   background: $cassiopeia-template-color;
 
   a {
-    color: #fff;
+    color: $white;
   }
 
   .back-top {
@@ -14,7 +14,7 @@
     height: 40px;
     padding: 8px 11px;
     color: $cassiopeia-template-color;
-    background: #fff;
+    background: $white;
     border-radius: 3px;
 
     @include margin("right", 5px);

--- a/templates/cassiopeia/scss/blocks/_form.scss
+++ b/templates/cassiopeia/scss/blocks/_form.scss
@@ -2,7 +2,7 @@
 
 .form-control {
   max-width: $input-max-width;
-  background-color: $white-offset;
+  background-color: $white;
 
   &.input-xlarge {
     max-width: 350px;

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -8,7 +8,7 @@ body {
   padding: 0;
   margin: 0;
   line-height: 1.6;
-  background: #fff;
+  background: $white;
 }
 
 img {

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -5,7 +5,7 @@
   z-index: 10;
   background-color: $cassiopeia-template-color;
   background-image: $cassiopeia-header-grad;
-  box-shadow: 0 5px 5px rgba(0, 0, 0, .03) inset;
+  box-shadow: 0 5px 5px hsla(0, 0%, 0%, .03) inset;
 
   @include media-breakpoint-down(sm) {
     position: relative !important;

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -25,7 +25,7 @@
 
   .site-description {
     font-size: 1rem;
-    color: $white-offset;
+    color: $white;
   }
 
   .navbar-brand {
@@ -34,7 +34,7 @@
     padding: 2.5rem ($cassiopeia-grid-gutter / 2);
     margin-right: auto;
     font-size: 2rem;
-    color: $white-offset;
+    color: $white;
 
     [dir=rtl] & {
       margin-right: 0;
@@ -52,7 +52,7 @@
 
     &:hover,
     &:focus {
-      color: darken($white-offset, 6%);
+      color: darken($white, 6%);
     }
   }
 
@@ -117,9 +117,9 @@
   }
 
   .navbar-toggler {
-    color: $white-offset;
+    color: $white;
     cursor: default;
-    border: 1px solid $white-offset;
+    border: 1px solid $white;
 
     .fas {
       font-size: 24px;

--- a/templates/cassiopeia/scss/blocks/_icons.scss
+++ b/templates/cassiopeia/scss/blocks/_icons.scss
@@ -9,7 +9,7 @@
 }
 
 .icon-white {
-  color: $white-offset;
+  color: $white;
 }
 
 .input-group-text {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -9,7 +9,7 @@
 }
 
 .container-header header .site {
-  background-color: #fafafa;
+  background-color: hsl(0, 0%, 98%);
 
   > .full-width {
     max-width: none;

--- a/templates/cassiopeia/scss/blocks/_modals.scss
+++ b/templates/cassiopeia/scss/blocks/_modals.scss
@@ -7,10 +7,10 @@
 
   .btn-primary:not([href]),
   .btn-success:not([href]) {
-    color: #fff;
+    color: $white;
 
     &:hover {
-      color: #fff;
+      color: $white;
     }
   }
 }

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -108,8 +108,8 @@
   padding: 0 ($cassiopeia-grid-gutter / 2) $cassiopeia-grid-gutter;
 
   .boxed & {
-    background-color: #fff;
-    box-shadow: 0 0 2px rgba(52, 58, 67, .1), 0 2px 5px rgba(52, 58, 67, .08), 0 5px 15px rgba(52, 58, 67, .08), inset 0 3px 0 $cassiopeia-template-color;
+    background-color: $white;
+    box-shadow: 0 0 2px hsla(216, 13%, 23%, .1), 0 2px 5px hsla(216, 13%, 23%, .08), 0 5px 15px hsla(216, 13%, 23%, .08), inset 0 3px 0 $cassiopeia-template-color;
 
     .item-content {
       padding: 25px;

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -1,7 +1,7 @@
 // TODO use _variables.scss
 html {
   background: radial-gradient(circle, #fdfdfd, #f1f1f1);
-  background-color: #3a92c8;
+  background-color: hsl(203, 56%, 51%);
   background-image: none;
   background-repeat: no-repeat;
   background-attachment: fixed;
@@ -11,7 +11,7 @@ body {
   padding: 0;
   margin: 0;
   font: 14px / 18px sans-serif;
-  color: #555;
+  color: hsl(0, 0%, 33%);
   background-color: transparent;
 }
 
@@ -31,10 +31,10 @@ body {
   width: 100%;
   max-width: 30em;
   margin: 0 auto 60px;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, .1);
+  background-color: hsl(0, 0%, 100%);
+  border: 1px solid hsla(0, 0%, 0%, .1);
   border-radius: 5px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, .05);
+  box-shadow: 0 0 10px hsla(0, 0%, 0%, .05);
 }
 
 .header {
@@ -57,8 +57,8 @@ html[dir=rtl] .header {
   left: 0;
   height: 3px;
   content: "";
-  background-color: #007eb7;
-  background-image: linear-gradient(to right, #59afff 0%, #59daff 100%);
+  background-color: hsl(199, 100%, 36%);
+  background-image: linear-gradient(to right, hsl(209, 100%, 67%) 0%, hsl(209, 100%, 67%) 100%);
 }
 
 .login {
@@ -105,10 +105,10 @@ input {
   z-index: 1;
   padding: 12px;
   margin-top: 2px;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, .05);
+  background-color: hsl(0, 0%, 100%);
+  border: 1px solid hsla(0, 0%, 0%, .05);
   border-radius: 50%;
-  box-shadow: 0 0 5px rgba(0, 0, 0, .075);
+  box-shadow: 0 0 5px hsla(0, 0%, 0%, .075);
   transform: translate(-50%, -50%);
 }
 

--- a/templates/cassiopeia/scss/vendor/_chosen.scss
+++ b/templates/cassiopeia/scss/vendor/_chosen.scss
@@ -49,7 +49,7 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
   }
 
   .chosen-drop {
-    background: $white-offset;
+    background: $white;
     border: $custom-select-border-width solid $custom-select-border-color;
   }
 

--- a/templates/cassiopeia/scss/vendor/_chosen.scss
+++ b/templates/cassiopeia/scss/vendor/_chosen.scss
@@ -91,7 +91,7 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
         right: 0;
         width: $chosen-multi-close-width;
         height: 100%;
-        background: rgba(0, 0, 0, .2);
+        background: hsla(0, 0%, 0%, .2);
         background-image: none !important;
 
         &::before {

--- a/templates/cassiopeia/scss/vendor/_dragula.scss
+++ b/templates/cassiopeia/scss/vendor/_dragula.scss
@@ -4,7 +4,7 @@
   position: fixed !important;
   z-index: 9999 !important;
   margin: 0 !important;
-  background-color: #90ee90;
+  background-color: hsl(120, 73%, 75%);
   opacity: .8;
 
   &.table {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -15,7 +15,7 @@
 
 .btn-secondary {
   color: $gray-800;
-  background-color: $white-offset;
+  background-color: $white;
   border-color: $gray-400;
 
   &:hover,

--- a/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
@@ -1,9 +1,9 @@
 // Alerts
 
 .card-grey {
-  background-color: #f7f7f9;
+  background-color: hsl(240, 14%, 97%);
 }
 
 .card-inverse {
-  color: rgba(255, 255, 255, .9);
+  color: hsla(0, 0%, 100%, .9);
 }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -17,7 +17,7 @@
 
   &[multiple] {
     padding: 0;
-    background-color: var(--white-offset);
+    background-color: var(--white);
 
     option {
       padding: $custom-select-multiple-padding-y $custom-select-padding-x;
@@ -38,7 +38,7 @@
 
       option {
         color: $custom-select-color;
-        background-color: $white-offset;
+        background-color: $white;
       }
     }
 
@@ -48,7 +48,7 @@
 
       option {
         color: $custom-select-color;
-        background-color: $white-offset;
+        background-color: $white;
       }
     }
   }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
@@ -3,7 +3,7 @@
 .dropdown-menu {
   padding: .2rem 0;
   margin-top: .5rem;
-  background-color: $white-offset;
+  background-color: $white;
   border-color: $cassiopeia-border-color;
 
   &::after {
@@ -12,7 +12,7 @@
     left: .9rem;
     font-family: "Font Awesome 5 Free";
     font-size: 1.6rem;
-    color: $white-offset;
+    color: $white;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, .2);
     content: "\f0d8";
   }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_nav.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_nav.scss
@@ -7,7 +7,7 @@
   border: 1px solid $cassiopeia-border-color;
   border-bottom: 0;
   border-radius: $border-radius $border-radius 0 0;
-  box-shadow: 0 1px #fff inset, 0 2px 3px -3px rgba(0, 0, 0, .15), 0 -4px 0 rgba(0, 0, 0, .05) inset, $cassiopeia-box-shadow;
+  box-shadow: 0 1px $white inset, 0 2px 3px -3px hsla(0, 0%, 0%, .15), 0 -4px 0 hsla(0, 0%, 0%, .05) inset, $cassiopeia-box-shadow;
 
   .nav-item {
     margin-bottom: 0;
@@ -17,16 +17,16 @@
 
       &.active {
         border-radius: $border-radius 0 0;
-        box-shadow: -1px 0 1px -1px rgba(0, 0, 0, .06), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+        box-shadow: -1px 0 1px -1px hsla(0, 0%, 0%, .06), inset -2px 0 1px -1px hsla(0, 0%, 0%, .08), inset 0 1px 0 hsla(0, 0%, 0%, .02);
       }
 
     }
 
     &:last-of-type .nav-link {
-      box-shadow: -1px 0 0 rgba(0, 0, 0, .05), 1px 0 0 rgba(0, 0, 0, .05);
+      box-shadow: -1px 0 0 hsla(0, 0%, 0%, .05), 1px 0 0 hsla(0, 0%, 0%, .05);
 
       &.active {
-        box-shadow: inset 2px 0 1px -1px rgba(0, 0, 0, .08), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+        box-shadow: inset 2px 0 1px -1px hsla(0, 0%, 0%, .08), inset -2px 0 1px -1px hsla(0, 0%, 0%, .08), inset 0 1px 0 hsla(0, 0%, 0%, .02);
       }
 
     }
@@ -40,16 +40,16 @@
     border: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    box-shadow: -1px 0 0 rgba(0, 0, 0, .05);
+    box-shadow: -1px 0 0 hsla(0, 0%, 0%, .05);
 
     &.active {
       background-color: $cassiopeia-tabs-active-bg;
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .05) 100%);
+      background-image: linear-gradient(to bottom, hsla(0, 0%, 0%, 0), hsla(0, 0%, 0%, .05) 100%);
       border-right: 0;
       border-left: 0;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
-      box-shadow: inset 2px 0 1px -1px rgba(0, 0, 0, .08), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+      box-shadow: inset 2px 0 1px -1px hsla(0, 0%, 0%, .08), inset -2px 0 1px -1px hsla(0, 0%, 0%, .08), inset 0 1px 0 hsla(0, 0%, 0%, .02);
 
       &::after {
         position: absolute;
@@ -70,7 +70,7 @@
 
 .nav-tabs + .tab-content {
   padding: 15px;
-  background: $white-offset;
+  background: $white;
   border: 1px solid;
   border-color: $cassiopeia-border-color;
   border-radius: 0 0 $border-radius $border-radius;

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -114,7 +114,7 @@
     }
 
     &::before {
-      color: #fff;
+      color: $white;
     }
   }
 }

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -36,25 +36,25 @@
 
   &[type="success"] {
     --alert-accent-color: var(--success);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, 0.95);
     --alert-close-button: var(--success);
   }
 
   &[type="info"] {
     --alert-accent-color: var(--info);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, 0.95);
     --alert-close-button: var(--info);
   }
 
   &[type="warning"] {
     --alert-accent-color: var(--warning);
-    --alert-heading-text: #000;
-    --alert-close-button: #000;
+    --alert-heading-text: $black;
+    --alert-close-button: $black;
   }
 
   &[type="danger"] {
     --alert-accent-color: var(--danger);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, 0.95);
     --alert-close-button: var(--danger);
   }
 

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -30,9 +30,9 @@
         &:hover,
         &:focus,
         &:active {
-          color: #000;
+          color: $black;
           text-decoration: none;
-          background-color: rgba(0, 0, 0, .1);
+          background-color: hsla(0, 0%, 0%, .1);
         }
       }
 
@@ -112,7 +112,7 @@
           z-index: 1001;
           min-width: 180px;
           margin-top: 5px;
-          box-shadow: 0 0 10px rgba(0, 0, 0, .1);
+          box-shadow: 0 0 10px hsla(0, 0%, 0%, .1);
         }
       }
     }


### PR DESCRIPTION
This PR 
- replaces $white-offset (#fefefe) by $white (#fff)
- replaces all hex, rgb and rgba colors by hsl and hsla colors
- applies code style to scss/_variables.scss
