### PR TITLE
Work in progess - Add a color theme switcher parameter, add css themes

### DIFF
--- a/language/en-GB/tpl_cassiopeia.ini
+++ b/language/en-GB/tpl_cassiopeia.ini
@@ -5,6 +5,12 @@
 
 TPL_CASSIOPEIA_BACKTOTOP="Back to Top"
 TPL_CASSIOPEIA_BACKTOTOP_LABEL="Back-to-top Link"
+TPL_CASSIOPEIA_COLOR_NAME_LABEL="Color Theme"
+TPL_CASSIOPEIA_COLOR_NAME_DESC="Select your color theme"
+TPL_CASSIOPEIA_FONT_LABEL="Google font for text and headings"
+TPL_CASSIOPEIA_FONT_DESC="Load Google font for text and headings (H1, H2, H3, etc)."
+TPL_CASSIOPEIA_FONT_NAME_LABEL="Google Font Name"
+TPL_CASSIOPEIA_FONT_NAME_DESC="Example: only one font Josefin Sans or a font combination Montserrat + Work Sans."
 TPL_CASSIOPEIA_FLUID="Fluid"
 TPL_CASSIOPEIA_FLUID_LABEL="Fluid Layout"
 TPL_CASSIOPEIA_LOGO_LABEL="Logo"

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -28,6 +28,17 @@ $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu->getParams()->get('pageclass_sfx');
 
+// Template path
+$templatePath = Uri::root() . 'templates/'.$this->template;
+
+// Color Theme
+$paramsColorName = $this->params->get('colorName');
+$assetColorName  = 'theme.' . $paramsColorName;
+$assetColorUri = $templatePath . '/css/global/' . $paramsColorName . '.css';
+//$wa->registerAndUseStyle('summer', 'templates/cassiopeia/css/global/summer.css');
+$wa->registerAndUseStyle($assetColorName, $assetColorUri);
+$this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
+
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.active.language')
@@ -51,7 +62,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = '<img src="' . $this->baseurl . '/templates/' . $this->template . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
+	$logo = '<img src="' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
 
 $hasClass = '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -35,7 +35,6 @@ $templatePath = Uri::root() . 'templates/'.$this->template;
 $paramsColorName = $this->params->get('colorName');
 $assetColorName  = 'theme.' . $paramsColorName;
 $assetColorUri = $templatePath . '/css/global/' . $paramsColorName . '.css';
-//$wa->registerAndUseStyle('summer', 'templates/cassiopeia/css/global/summer.css');
 $wa->registerAndUseStyle($assetColorName, $assetColorUri);
 $this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -32,6 +32,24 @@ h6 {
   font-weight: bold;
 }
 
+a {
+  color: var(--cassiopeia-color-primary);
+}
+a:hover {
+  color: var(--cassiopeia-color-hover);
+}
+a.navbar-brand {
+  color: var(--cassiopeia-color-brand);
+}
+
+.btn-primary {
+  background-color: var(--cassiopeia-color-primary);
+  border-color: var(--cassiopeia-color-primary);
+  &:hover {
+    background-color: var(--cassiopeia-color-hover);
+    border-color: var(--cassiopeia-color-hover);
+  }
+}
 small,
 .small {
   font-size: $font-size-sm;

--- a/templates/cassiopeia/scss/global/autumm.scss
+++ b/templates/cassiopeia/scss/global/autumm.scss
@@ -1,0 +1,5 @@
+:root {
+  --cassiopeia-color-primary: #2e7099;
+  --cassiopeia-color-hover: #45a8e6;
+  --cassiopeia-color-brand: #2e4e6d;
+}

--- a/templates/cassiopeia/scss/global/spring.scss
+++ b/templates/cassiopeia/scss/global/spring.scss
@@ -1,0 +1,5 @@
+:root {
+  --cassiopeia-color-primary: #426b00;
+  --cassiopeia-color-hover: #dbd30f;
+  --cassiopeia-color-brand: #6c6900;
+}

--- a/templates/cassiopeia/scss/global/summer.scss
+++ b/templates/cassiopeia/scss/global/summer.scss
@@ -1,0 +1,5 @@
+:root {
+  --cassiopeia-color-primary: #e89b41;
+  --cassiopeia-color-hover: #f57122;
+  --cassiopeia-color-brand: #ff5624;
+}

--- a/templates/cassiopeia/scss/global/winter.scss
+++ b/templates/cassiopeia/scss/global/winter.scss
@@ -1,0 +1,5 @@
+:root {
+  --cassiopeia-color-primary: #a6a6a6;
+  --cassiopeia-color-hover: #d9d9d9;
+  --cassiopeia-color-brand: #1d1d1d;
+}

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -81,6 +81,20 @@
 				</field>
 
 				<field
+					name="colorName"
+					type="filelist"
+					label="TPL_CASSIOPEIA_COLOR_NAME_LABEL"
+					description="TPL_CASSIOPEIA_COLOR_NAME_DESC"
+					stripext="1"
+					directory="templates/cassiopeia/css/global/"
+					hide_none="1"
+					hide_default="1"
+					fileFilter="\.css$"
+					exclude="\.min\.css$"
+					default="summer"
+				/>
+
+				<field
 					name="stickyHeader"
 					type="radio"
 					label="TPL_CASSIOPEIA_STICKY_LABEL"


### PR DESCRIPTION
Pull Request for Issue #51  .

### Summary of Changes
Added a new parameter: Color Theme
Created new scss files for the global definitions of colors as css variables for each theme
Load css depending on the selected theme

### Testing Instructions
Install PR and run npm ci or complie scss

Change the theme in the template configuration and reload the page. You should see that links and buttons change the colors depending on the selected theme.

**Autumm**
![Screenshot_2020-09-04 Home-autumm](https://user-images.githubusercontent.com/9153168/92231040-5c630400-eeac-11ea-9757-81f0b06ac4c1.png)

**Spring**
![Screenshot_2020-09-04 Home-spring](https://user-images.githubusercontent.com/9153168/92231044-5cfb9a80-eeac-11ea-8d4a-4dbfe8f2b3f1.png)

**Summer**
![Screenshot_2020-09-04 Home-summer](https://user-images.githubusercontent.com/9153168/92231046-5d943100-eeac-11ea-9c6b-3c51dee2f3b8.png)

**Winter**
![Screenshot_2020-09-04 Home-winter](https://user-images.githubusercontent.com/9153168/92231047-5d943100-eeac-11ea-9c93-5bcd42b12dcc.png)

