### PR TITLE
convert rgb(a) and hex colors to hsl(a) colors

### DIFF
--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -1,7 +1,7 @@
 // Banner
 
 .container-banner {
-  color: #fff;
+  color: $white;
 
   img {
     display: block;
@@ -21,8 +21,8 @@
       align-items: center;
       justify-content: center;
       height: 100%;
-      color: #fff;
-      background-color: rgba(0,0,0,.5);
+      color: $white;
+      background-color: hsla(0, 0%, 0%, .5);
 
       h2 {
         font-size: 3rem;

--- a/templates/cassiopeia/scss/blocks/_demo-styling.scss
+++ b/templates/cassiopeia/scss/blocks/_demo-styling.scss
@@ -1,6 +1,6 @@
 // Demo Styling
 
-$inverted-color: rgba(255, 255, 255, .9);
+$inverted-color: hsla(0, 0%, 100%, .9);
 
 .demo-module {
   text-align: center;

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -2,11 +2,11 @@
 
 .footer {
   padding: 2.5rem ($cassiopeia-grid-gutter / 2);
-  color: #fff;
+  color: $white;
   background: $cassiopeia-template-color;
 
   a {
-    color: #fff;
+    color: $white;
   }
 
   .back-top {
@@ -14,7 +14,7 @@
     height: 40px;
     padding: 8px 11px;
     color: $cassiopeia-template-color;
-    background: #fff;
+    background: $white;
     border-radius: 3px;
 
     @include margin("right", 5px);

--- a/templates/cassiopeia/scss/blocks/_form.scss
+++ b/templates/cassiopeia/scss/blocks/_form.scss
@@ -2,7 +2,7 @@
 
 .form-control {
   max-width: $input-max-width;
-  background-color: $white-offset;
+  background-color: $white;
 
   &.input-xlarge {
     max-width: 21.875rem;

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -16,7 +16,7 @@ body {
   padding: 0;
   margin: 0;
   line-height: 1.6;
-  background: #fff;
+  background: $white;
 }
 
 img {
@@ -34,7 +34,7 @@ h6 {
 
 a {
   color: var(--cassiopeia-color-primary);
-  
+
   &:hover,
   &:focus {
     color: var(--cassiopeia-color-hover);
@@ -48,7 +48,7 @@ a {
 .btn-primary {
   background-color: var(--cassiopeia-color-primary);
   border-color: var(--cassiopeia-color-primary);
-  
+
   &:hover,
   &:focus {
     background-color: var(--cassiopeia-color-hover);

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -5,7 +5,7 @@
   z-index: 10;
   background-color: $cassiopeia-template-color;
   background-image: $cassiopeia-header-grad;
-  box-shadow: 0 5px 5px rgba(0, 0, 0, .03) inset;
+  box-shadow: 0 5px 5px hsla(0, 0%, 0%,.03) inset;
 
   @include media-breakpoint-down(sm) {
     position: relative !important;
@@ -25,7 +25,7 @@
 
   .site-description {
     font-size: 1rem;
-    color: $white-offset;
+    color: $white;
   }
 
   .navbar-brand {
@@ -34,7 +34,7 @@
     padding: 2.5rem ($cassiopeia-grid-gutter / 2);
     margin-right: auto;
     font-size: 2rem;
-    color: $white-offset;
+    color: $white;
 
     [dir=rtl] & {
       margin-right: 0;
@@ -52,7 +52,7 @@
 
     &:hover,
     &:focus {
-      color: darken($white-offset, 6%);
+      color: darken($white, 6%);
     }
   }
 
@@ -104,9 +104,9 @@
   }
 
   .navbar-toggler {
-    color: $white-offset;
+    color: $white;
     cursor: default;
-    border: 1px solid $white-offset;
+    border: 1px solid $white;
 
     .fas {
       font-size: 24px;

--- a/templates/cassiopeia/scss/blocks/_icons.scss
+++ b/templates/cassiopeia/scss/blocks/_icons.scss
@@ -9,7 +9,7 @@
 }
 
 .icon-white {
-  color: $white-offset;
+  color: $white;
 }
 
 .input-group-text {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -10,7 +10,7 @@
 }
 
 .container-header header .site {
-  background-color: #fafafa;
+  background-color: $gray-100;
 
   > .full-width {
     max-width: none;

--- a/templates/cassiopeia/scss/blocks/_modals.scss
+++ b/templates/cassiopeia/scss/blocks/_modals.scss
@@ -7,10 +7,10 @@
 
   .btn-primary:not([href]),
   .btn-success:not([href]) {
-    color: #fff;
+    color: $white;
 
     &:hover {
-      color: #fff;
+      color: $white;
     }
   }
 }

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -108,8 +108,8 @@
   padding: 0 ($cassiopeia-grid-gutter / 2) $cassiopeia-grid-gutter;
 
   .boxed & {
-    background-color: #fff;
-    box-shadow: 0 0 2px rgba(52, 58, 67, .1), 0 2px 5px rgba(52, 58, 67, .08), 0 5px 15px rgba(52, 58, 67, .08), inset 0 3px 0 $cassiopeia-template-color;
+    background-color: $white;
+    box-shadow: 0 0 2px hsla(216, 13%, 23%, .1), 0 2px 5px hsla(216, 13%, 23%, .08), 0 5px 15px hsla(216, 13%, 23%, .08), inset 0 3px 0 $cassiopeia-template-color;
 
     .item-content {
       padding: 25px;

--- a/templates/cassiopeia/scss/global/colors_autumn.scss
+++ b/templates/cassiopeia/scss/global/colors_autumn.scss
@@ -1,5 +1,5 @@
 :root {
-  --cassiopeia-color-primary: #2e7099;
-  --cassiopeia-color-hover: #45a8e6;
-  --cassiopeia-color-brand: #2e4e6d;
+  --cassiopeia-color-primary: hsl(203, 54%, 39%);
+  --cassiopeia-color-hover: hsl(203, 76%, 59%);
+  --cassiopeia-color-brand: hsl(210, 41%, 30%);
 }

--- a/templates/cassiopeia/scss/global/colors_spring.scss
+++ b/templates/cassiopeia/scss/global/colors_spring.scss
@@ -1,5 +1,5 @@
 :root {
-  --cassiopeia-color-primary: #426b00;
-  --cassiopeia-color-hover: #dbd30f;
-  --cassiopeia-color-brand: #6c6900;
+  --cassiopeia-color-primary: hsl(83, 100%, 21%);
+  --cassiopeia-color-hover: hsl(58, 87%, 46%);
+  --cassiopeia-color-brand: hsl(58, 100%, 21%);
 }

--- a/templates/cassiopeia/scss/global/colors_summer.scss
+++ b/templates/cassiopeia/scss/global/colors_summer.scss
@@ -1,5 +1,5 @@
 :root {
-  --cassiopeia-color-primary: #e89b41;
-  --cassiopeia-color-hover: #f57122;
-  --cassiopeia-color-brand: #ff5624;
+  --cassiopeia-color-primary: hsl(32, 78%, 58%);
+  --cassiopeia-color-hover: hsl(22, 91%, 55%);
+  --cassiopeia-color-brand: hsl(14, 100%, 57%);
 }

--- a/templates/cassiopeia/scss/global/colors_winter.scss
+++ b/templates/cassiopeia/scss/global/colors_winter.scss
@@ -1,5 +1,5 @@
 :root {
-  --cassiopeia-color-primary: #a6a6a6;
-  --cassiopeia-color-hover: #d9d9d9;
-  --cassiopeia-color-brand: #1d1d1d;
+  --cassiopeia-color-primary: hsl(0, 0%, 65%);
+  --cassiopeia-color-hover: hsl(0, 0%, 85%);
+  --cassiopeia-color-brand: hsl(0, 0%, 11%);
 }

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -1,7 +1,7 @@
 // TODO use _variables.scss
 html {
-  background: radial-gradient(circle, #fdfdfd, #f1f1f1);
-  background-color: #3a92c8;
+  background: radial-gradient(circle, $gray-100, $gray-200);
+  background-color: $cyan;
   background-image: none;
   background-repeat: no-repeat;
   background-attachment: fixed;
@@ -11,7 +11,7 @@ body {
   padding: 0;
   margin: 0;
   font: 14px / 18px sans-serif;
-  color: #555;
+  color: $gray-700;
   background-color: transparent;
 }
 
@@ -31,10 +31,10 @@ body {
   width: 100%;
   max-width: 30em;
   margin: 0 auto 60px;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, .1);
+  background-color: $white;
+  border: 1px solid hsla(0, 0%, 0%,.1);
   border-radius: 5px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, .05);
+  box-shadow: 0 0 10px hsla(0, 0%, 0%,.05);
 }
 
 .header {
@@ -57,8 +57,8 @@ html[dir=rtl] .header {
   left: 0;
   height: 3px;
   content: "";
-  background-color: #007eb7;
-  background-image: linear-gradient(to right, #59afff 0%, #59daff 100%);
+  background-color: hsl(199, 100%, 36%);
+  background-image: linear-gradient(to right, hsl(209, 100%, 67%) 0%, hsl(193, 100%, 67%) 100%);
 }
 
 .login {
@@ -105,10 +105,10 @@ input {
   z-index: 1;
   padding: 12px;
   margin-top: 2px;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, .05);
+  background-color: $white;
+  border: 1px solid hsla(0, 0%, 0%,.05);
   border-radius: 50%;
-  box-shadow: 0 0 5px rgba(0, 0, 0, .075);
+  box-shadow: 0 0 5px hsla(0, 0%, 0%,.075);
   transform: translate(-50%, -50%);
 }
 

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -1,4 +1,9 @@
-// TODO use _variables.scss
+// Bootstrap functions
+@import "../../../media/vendor/bootstrap/scss/functions";
+
+// Variables, Functions and Mixins
+@import "tools/tools";
+
 html {
   background: radial-gradient(circle, $gray-100, $gray-200);
   background-color: $cyan;

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -1,24 +1,24 @@
 // Global
-$cassiopeia-template-color-dark:     hsl(220, 67%, 20%) !default;
-$cassiopeia-template-color:          hsl(242, 30%, 36%) !default;
-$cassiopeia-container-main-bg:       hsl(0, 0%, 95%) !default;
-$cassiopeia-border-color:            hsl(210, 14%, 89%) !default;
-$cassiopeia-box-shadow:              0 0 3px hsla(0, 0%, 0%, 0.04) !default;
-$cassiopeia-block-header-bg:         hsl(0, 0%, 96%) !default;
-$cassiopeia-header-grad:             linear-gradient(135deg, $cassiopeia-template-color-dark 0%, $cassiopeia-template-color 100%);
-$input-max-width:                    100%;
+$cassiopeia-template-color-dark:      hsl(220, 67%, 20%) !default;
+$cassiopeia-template-color:           hsl(242, 30%, 36%) !default;
+$cassiopeia-container-main-bg:        hsl(0, 0%, 95%) !default;
+$cassiopeia-border-color:             hsl(210, 14%, 89%) !default;
+$cassiopeia-box-shadow:               0 0 3px hsla(0, 0%, 0%, 0.04) !default;
+$cassiopeia-block-header-bg:          hsl(0, 0%, 96%) !default;
+$cassiopeia-header-grad:              linear-gradient(135deg, $cassiopeia-template-color-dark 0%, $cassiopeia-template-color 100%);
+$input-max-width:                     100%;
 
-$white:                              hsl(0, 0%, 100%);
-$gray-100:                           hsl(210, 17%, 98%);
-$gray-200:                           hsl(210, 16%, 93%);
-$gray-300:                           hsl(210, 14%, 89%);
-$gray-400:                           hsl(210, 14%, 83%);
-$gray-500:                           hsl(210, 11%, 71%);
-$gray-600:                           hsl(208, 7%, 46%);
-$gray-700:                           hsl(210, 9%, 31%);
-$gray-800:                           hsl(210, 10%, 23%);
-$gray-900:                           hsl(210, 11%, 15%);
-$black:                              hsl(0, 0%, 0%);
+$white:                               hsl(0, 0%, 100%);
+$gray-100:                            hsl(210, 17%, 98%);
+$gray-200:                            hsl(210, 16%, 93%);
+$gray-300:                            hsl(210, 14%, 89%);
+$gray-400:                            hsl(210, 14%, 83%);
+$gray-500:                            hsl(210, 11%, 71%);
+$gray-600:                            hsl(208, 7%, 46%);
+$gray-700:                            hsl(210, 9%, 31%);
+$gray-800:                            hsl(210, 10%, 23%);
+$gray-900:                            hsl(210, 11%, 15%);
+$black:                               hsl(0, 0%, 0%);
 
 $grays: (
   100: $gray-100,
@@ -32,16 +32,16 @@ $grays: (
   900: $gray-900
 );
 
-$blue:                               $cassiopeia-template-color-dark;
-$indigo:                             hsl(263, 90%, 51%);
-$purple:                             hsl(261, 51%, 51%);
-$pink:                               hsl(332, 79%, 58%);
-$red:                                hsl(2, 64%, 58%);
-$orange:                             hsl(27, 98%, 54%);
-$yellow:                             hsl(35, 84%, 62%);
-$green:                              hsl(120, 32%, 39%);
-$teal:                               hsl(194, 66%, 61%);
-$cyan:                               hsl(188, 80%, 32%);
+$blue:                                $cassiopeia-template-color-dark;
+$indigo:                              hsl(263, 90%, 51%);
+$purple:                              hsl(261, 51%, 51%);
+$pink:                                hsl(332, 79%, 58%);
+$red:                                 hsl(2, 64%, 58%);
+$orange:                              hsl(27, 98%, 54%);
+$yellow:                              hsl(35, 84%, 62%);
+$green:                               hsl(120, 32%, 39%);
+$teal:                                hsl(194, 66%, 61%);
+$cyan:                                hsl(188, 80%, 32%);
 
 $colors: (
   blue: $blue,
@@ -71,91 +71,91 @@ $theme-colors: (
 );
 
 // Toolbar
-$cassiopeia-toolbar-line-height:         1.8rem;
+$cassiopeia-toolbar-line-height:      1.8rem;
 
 // Fonts
-$cassiopeia-inverted-text-color:     $cassiopeia-template-color;
-$font-size-root:                     1em;
-$h1-font-size:                       1.857rem;
-$h2-font-size:                       1.571rem;
-$h3-font-size:                       1.286rem;
-$h4-font-size:                       1rem;
-$h5-font-size:                       .9286rem;
-$h6-font-size:                       .8571rem;
-$font-size-sm:                       .8rem;
-$fa-font-path:                       "../../../media/vendor/fontawesome-free/webfonts";
+$cassiopeia-inverted-text-color:      $cassiopeia-template-color;
+$font-size-root:                      1em;
+$h1-font-size:                        1.857rem;
+$h2-font-size:                        1.571rem;
+$h3-font-size:                        1.286rem;
+$h4-font-size:                        1rem;
+$h5-font-size:                        .9286rem;
+$h6-font-size:                        .8571rem;
+$font-size-sm:                        .8rem;
+$fa-font-path:                        "../../../media/vendor/fontawesome-free/webfonts";
 
 // Border Radius
-$border-radius:               .25rem !default;
-$border-radius-lg:            .3rem !default;
-$border-radius-sm:            .2rem !default;
+$border-radius:                       .25rem !default;
+$border-radius-lg:                    .3rem !default;
+$border-radius-sm:                    .2rem !default;
 
 // Tables
-$table-bg:                           transparent !default;
-$table-bg-accent:                    hsla(0, 0%, 0%, .3) !default;
+$table-bg:                            transparent !default;
+$table-bg-accent:                     hsla(0, 0%, 0%, .3) !default;
 
 // Tabs
-$cassiopeia-tabs-header-bg:              $cassiopeia-block-header-bg;
-$cassiopeia-tabs-active-bg:              hsla(0, 0%, 0%, .3);
-$cassiopeia-tabs-active-highlight:       theme-color("primary");
+$cassiopeia-tabs-header-bg:           $cassiopeia-block-header-bg;
+$cassiopeia-tabs-active-bg:           hsla(0, 0%, 0%, .3);
+$cassiopeia-tabs-active-highlight:    theme-color("primary");
 
 // Cards
-$cassiopeia-card-title-bg:               $cassiopeia-block-header-bg;
-$cassiopeia-card-title-icon-bg:          $cassiopeia-block-header-bg;
-$cassiopeia-card-title-icon-bg-hover:    darken($cassiopeia-card-title-bg, 2%);
-$card-bg-color-light:                $gray-100;
-$card-bg-color-dark:                 $cassiopeia-template-color;
-$card-border-color:                  $cassiopeia-border-color;
+$cassiopeia-card-title-bg:            $cassiopeia-block-header-bg;
+$cassiopeia-card-title-icon-bg:       $cassiopeia-block-header-bg;
+$cassiopeia-card-title-icon-bg-hover: darken($cassiopeia-card-title-bg, 2%);
+$card-bg-color-light:                 $gray-100;
+$card-bg-color-dark:                  $cassiopeia-template-color;
+$card-border-color:                   $cassiopeia-border-color;
 
 // Alerts
-$state-success-text:                 $white !default;
-$state-success-bg:                   theme-color("success") !default;
-$state-success-border:               darken(theme-color("success"), 5%) !default;
+$state-success-text:                  $white !default;
+$state-success-bg:                    theme-color("success") !default;
+$state-success-border:                darken(theme-color("success"), 5%) !default;
 
-$state-info-text:                    $white !default;
-$state-info-bg:                      theme-color("info") !default;
-$state-info-border:                  darken(theme-color("info"), 7%) !default;
+$state-info-text:                     $white !default;
+$state-info-bg:                       theme-color("info") !default;
+$state-info-border:                   darken(theme-color("info"), 7%) !default;
 
-$state-warning-text:                 $white !default;
-$state-warning-bg:                   theme-color("warning") !default;
-$state-warning-border:               darken(theme-color("warning"), 5%) !default;
+$state-warning-text:                  $white !default;
+$state-warning-bg:                    theme-color("warning") !default;
+$state-warning-border:                darken(theme-color("warning"), 5%) !default;
 
-$state-danger-text:                  $white !default;
-$state-danger-bg:                    theme-color("danger") !default;
-$state-danger-border:                darken(theme-color("danger"), 5%) !default;
+$state-danger-text:                   $white !default;
+$state-danger-bg:                     theme-color("danger") !default;
+$state-danger-border:                 darken(theme-color("danger"), 5%) !default;
 
 // Treeselect
-$treeselect-line-height:             2.2rem;
+$treeselect-line-height:              2.2rem;
 
 // List
-$list-group-bg:                      $white;
+$list-group-bg:                       $white;
 
 // Custom form
-$custom-select-bg:                   $gray-200;
+$custom-select-bg:                    $gray-200;
 
 // Custom form
-$custom-select-indicator-padding:    3rem;
-$custom-select-bg-size:              116rem;
-$custom-select-indicator:            url("../images/select-bg.svg");
-$custom-select-indicator-rtl:        url("../images/select-bg-rtl.svg");
-$custom-select-indicator-active:     url("../../../images/select-bg.svg");
-$custom-select-indicator-active-rtl: url("../../../images/select-bg-rtl.svg");
-$custom-select-background:           $custom-select-indicator no-repeat right center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
-$custom-select-background-rtl:       $custom-select-indicator-rtl no-repeat left center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
-$custom-select-bg-size-sm:           75rem;
-$custom-select-multiple-padding-y:   .3rem;
+$custom-select-indicator-padding:     3rem;
+$custom-select-bg-size:               116rem;
+$custom-select-indicator:             url("../images/select-bg.svg");
+$custom-select-indicator-rtl:         url("../images/select-bg-rtl.svg");
+$custom-select-indicator-active:      url("../../../images/select-bg.svg");
+$custom-select-indicator-active-rtl:  url("../../../images/select-bg-rtl.svg");
+$custom-select-background:            $custom-select-indicator no-repeat right center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
+$custom-select-background-rtl:        $custom-select-indicator-rtl no-repeat left center / $custom-select-bg-size; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
+$custom-select-bg-size-sm:            75rem;
+$custom-select-multiple-padding-y:    .3rem;
 
 //input
-$input-padding:                    .6rem 1rem;
-$input-border:                     solid 1px $gray-600;
-$input-btn-padding-y:              .6rem;
-$input-btn-padding-x:              1rem;
+$input-padding:                       .6rem 1rem;
+$input-border:                        solid 1px $gray-600;
+$input-btn-padding-y:                 .6rem;
+$input-btn-padding-x:                 1rem;
 
 // Modals
-$modal-header-height:                46px;
+$modal-header-height:                 46px;
 
 // Badges
-$badge-default-bg:                   $gray-600;
+$badge-default-bg:                    $gray-600;
 
 // Grid breakpoints
 //
@@ -186,23 +186,23 @@ $container-max-widths: (
 //
 // Set the number of columns and specify the width of the gutters.
 
-$grid-gutter-width:                  1em !default;
-$cassiopeia-grid-gutter:             $grid-gutter-width;
+$grid-gutter-width:                   1em !default;
+$cassiopeia-grid-gutter:              $grid-gutter-width;
 
 // Z-Index list
-$zindex-negative:                  -1;
-$zindex-actions:                   auto;
-$zindex-toolbar:                   1000;
-$zindex-sidebar:                   1010;
-$zindex-header:                    1020;
-$zindex-alerts:                    1030;
-$zindex-modal-backdrop:            1040;
-$zindex-modal:                     1050;
-$zindex-popover:                   1060;
-$zindex-tooltip:                   1070;
-$zindex-mobile-bottom:             8000;
-$zindex-mobile-toggle:             9999;
-$zindex-mobile-menu:               9000;
+$zindex-negative:                     -1;
+$zindex-actions:                      auto;
+$zindex-toolbar:                      1000;
+$zindex-sidebar:                      1010;
+$zindex-header:                       1020;
+$zindex-alerts:                       1030;
+$zindex-modal-backdrop:               1040;
+$zindex-modal:                        1050;
+$zindex-popover:                      1060;
+$zindex-tooltip:                      1070;
+$zindex-mobile-bottom:                8000;
+$zindex-mobile-toggle:                9999;
+$zindex-mobile-menu:                  9000;
 
 // MetisMenu
-$metismenu:                        true !default;
+$metismenu:                           true !default;

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -1,25 +1,24 @@
 // Global
-$cassiopeia-template-color-dark:     #112856 !default;
-$cassiopeia-template-color:          #434178 !default;
-$cassiopeia-container-main-bg:       #f2f2f2 !default;
-$cassiopeia-border-color:            #dee2e6 !default;
-$cassiopeia-box-shadow:              0 0 3px rgba(0,0,0,.04) !default;
-$cassiopeia-block-header-bg:         #f5f5f5 !default;
-$white-offset:                       #fefefe;
+$cassiopeia-template-color-dark:     hsl(220, 67%, 20%) !default;
+$cassiopeia-template-color:          hsl(242, 30%, 36%) !default;
+$cassiopeia-container-main-bg:       hsl(0, 0%, 95%) !default;
+$cassiopeia-border-color:            hsl(210, 14%, 89%) !default;
+$cassiopeia-box-shadow:              0 0 3px hsla(0, 0%, 0%, 0.04) !default;
+$cassiopeia-block-header-bg:         hsl(0, 0%, 96%) !default;
 $cassiopeia-header-grad:             linear-gradient(135deg, $cassiopeia-template-color-dark 0%, $cassiopeia-template-color 100%);
 $input-max-width:                    100%;
 
-$white:                              #fff;
-$gray-100:                           #f8f9fa;
-$gray-200:                           #e9ecef;
-$gray-300:                           #dee2e6;
-$gray-400:                           #ced4da;
-$gray-500:                           #adb5bd;
-$gray-600:                           #6c757d;
-$gray-700:                           #495057;
-$gray-800:                           #343a40;
-$gray-900:                           #212529;
-$black:                              #000;
+$white:                              hsl(0, 0%, 100%);
+$gray-100:                           hsl(210, 17%, 98%);
+$gray-200:                           hsl(210, 16%, 93%);
+$gray-300:                           hsl(210, 14%, 89%);
+$gray-400:                           hsl(210, 14%, 83%);
+$gray-500:                           hsl(210, 11%, 71%);
+$gray-600:                           hsl(208, 7%, 46%);
+$gray-700:                           hsl(210, 9%, 31%);
+$gray-800:                           hsl(210, 10%, 23%);
+$gray-900:                           hsl(210, 11%, 15%);
+$black:                              hsl(0, 0%, 0%);
 
 $grays: (
   100: $gray-100,
@@ -34,15 +33,15 @@ $grays: (
 );
 
 $blue:                               $cassiopeia-template-color-dark;
-$indigo:                             #6610f2;
-$purple:                             #6f42c1;
-$pink:                               #e83e8c;
-$red:                                #d9534f;
-$orange:                             #fd7e14;
-$yellow:                             #f0ad4e;
-$green:                              #438243;
-$teal:                               #5bc0de;
-$cyan:                               #108193;
+$indigo:                             hsl(263, 90%, 51%);
+$purple:                             hsl(261, 51%, 51%);
+$pink:                               hsl(332, 79%, 58%);
+$red:                                hsl(2, 64%, 58%);
+$orange:                             hsl(27, 98%, 54%);
+$yellow:                             hsl(35, 84%, 62%);
+$green:                              hsl(120, 32%, 39%);
+$teal:                               hsl(194, 66%, 61%);
+$cyan:                               hsl(188, 80%, 32%);
 
 $colors: (
   blue: $blue,
@@ -93,18 +92,18 @@ $border-radius-sm:            .2rem !default;
 
 // Tables
 $table-bg:                           transparent !default;
-$table-bg-accent:                    rgba(0,0,0,.03) !default;
+$table-bg-accent:                    hsla(0, 0%, 0%, .3) !default;
 
 // Tabs
 $cassiopeia-tabs-header-bg:              $cassiopeia-block-header-bg;
-$cassiopeia-tabs-active-bg:              rgba(0,0,0,.03);
+$cassiopeia-tabs-active-bg:              hsla(0, 0%, 0%, .3);
 $cassiopeia-tabs-active-highlight:       theme-color("primary");
 
 // Cards
 $cassiopeia-card-title-bg:               $cassiopeia-block-header-bg;
 $cassiopeia-card-title-icon-bg:          $cassiopeia-block-header-bg;
 $cassiopeia-card-title-icon-bg-hover:    darken($cassiopeia-card-title-bg, 2%);
-$card-bg-color-light:                #f8f8f8;
+$card-bg-color-light:                $gray-100;
 $card-bg-color-dark:                 $cassiopeia-template-color;
 $card-border-color:                  $cassiopeia-border-color;
 
@@ -129,7 +128,7 @@ $state-danger-border:                darken(theme-color("danger"), 5%) !default;
 $treeselect-line-height:             2.2rem;
 
 // List
-$list-group-bg:                      $white-offset;
+$list-group-bg:                      $white;
 
 // Custom form
 $custom-select-bg:                   $gray-200;
@@ -148,7 +147,7 @@ $custom-select-multiple-padding-y:   .3rem;
 
 //input
 $input-padding:                    .6rem 1rem;
-$input-border:                     solid 1px  #6d7784;
+$input-border:                     solid 1px $gray-600;
 $input-btn-padding-y:              .6rem;
 $input-btn-padding-x:              1rem;
 
@@ -156,7 +155,7 @@ $input-btn-padding-x:              1rem;
 $modal-header-height:                46px;
 
 // Badges
-$badge-default-bg:                   #5e7082;
+$badge-default-bg:                   $gray-600;
 
 // Grid breakpoints
 //

--- a/templates/cassiopeia/scss/vendor/_chosen.scss
+++ b/templates/cassiopeia/scss/vendor/_chosen.scss
@@ -49,7 +49,7 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
   }
 
   .chosen-drop {
-    background: $white-offset;
+    background: $white;
     border: $custom-select-border-width solid $custom-select-border-color;
   }
 
@@ -91,7 +91,7 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
         right: 0;
         width: $chosen-multi-close-width;
         height: 100%;
-        background: rgba(0, 0, 0, .2);
+        background: hsla(0, 0%, 0%,.2);
         background-image: none !important;
 
         &::before {

--- a/templates/cassiopeia/scss/vendor/_dragula.scss
+++ b/templates/cassiopeia/scss/vendor/_dragula.scss
@@ -4,7 +4,7 @@
   position: fixed !important;
   z-index: 9999 !important;
   margin: 0 !important;
-  background-color: #90ee90;
+  background-color: hsl(120, 73%, 75%);
   opacity: .8;
 
   &.table {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -15,7 +15,7 @@
 
 .btn-secondary {
   color: $gray-800;
-  background-color: $white-offset;
+  background-color: $white;
   border-color: $gray-400;
 
   &:hover,

--- a/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
@@ -1,9 +1,9 @@
 // Alerts
 
 .card-grey {
-  background-color: #f7f7f9;
+  background-color: $gray-100;
 }
 
 .card-inverse {
-  color: rgba(255, 255, 255, .9);
+  color: hsla(0, 0%, 100%, .9);
 }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -17,7 +17,7 @@
 
   &[multiple] {
     padding: 0;
-    background-color: var(--white-offset);
+    background-color: var(--white);
 
     option {
       padding: $custom-select-multiple-padding-y $custom-select-padding-x;
@@ -38,7 +38,7 @@
 
       option {
         color: $custom-select-color;
-        background-color: $white-offset;
+        background-color: $white;
       }
     }
 
@@ -48,7 +48,7 @@
 
       option {
         color: $custom-select-color;
-        background-color: $white-offset;
+        background-color: $white;
       }
     }
   }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
@@ -3,7 +3,7 @@
 .dropdown-menu {
   padding: .2rem 0;
   margin-top: .5rem;
-  background-color: $white-offset;
+  background-color: $white;
   border-color: $cassiopeia-border-color;
 
   &::after {
@@ -12,8 +12,8 @@
     left: .9rem;
     font-family: "Font Awesome 5 Free";
     font-size: 1.6rem;
-    color: $white-offset;
-    text-shadow: 0 -1px 0 rgba(0, 0, 0, .2);
+    color: $white;
+    text-shadow: 0 -1px 0 hsla(0, 0%, 0%,.2);
     content: "\f0d8";
   }
 

--- a/templates/cassiopeia/scss/vendor/bootstrap/_nav.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_nav.scss
@@ -7,7 +7,7 @@
   border: 1px solid $cassiopeia-border-color;
   border-bottom: 0;
   border-radius: $border-radius $border-radius 0 0;
-  box-shadow: 0 1px #fff inset, 0 2px 3px -3px rgba(0, 0, 0, .15), 0 -4px 0 rgba(0, 0, 0, .05) inset, $cassiopeia-box-shadow;
+  box-shadow: 0 1px $white inset, 0 2px 3px -3px hsla(0, 0%, 0%,.15), 0 -4px 0 hsla(0, 0%, 0%,.05) inset, $cassiopeia-box-shadow;
 
   .nav-item {
     margin-bottom: 0;
@@ -17,16 +17,16 @@
 
       &.active {
         border-radius: $border-radius 0 0;
-        box-shadow: -1px 0 1px -1px rgba(0, 0, 0, .06), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+        box-shadow: -1px 0 1px -1px hsla(0, 0%, 0%,.06), inset -2px 0 1px -1px hsla(0, 0%, 0%,.08), inset 0 1px 0 hsla(0, 0%, 0%,.02);
       }
 
     }
 
     &:last-of-type .nav-link {
-      box-shadow: -1px 0 0 rgba(0, 0, 0, .05), 1px 0 0 rgba(0, 0, 0, .05);
+      box-shadow: -1px 0 0 hsla(0, 0%, 0%,.05), 1px 0 0 hsla(0, 0%, 0%,.05);
 
       &.active {
-        box-shadow: inset 2px 0 1px -1px rgba(0, 0, 0, .08), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+        box-shadow: inset 2px 0 1px -1px hsla(0, 0%, 0%,.08), inset -2px 0 1px -1px hsla(0, 0%, 0%,.08), inset 0 1px 0 hsla(0, 0%, 0%,.02);
       }
 
     }
@@ -40,16 +40,16 @@
     border: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    box-shadow: -1px 0 0 rgba(0, 0, 0, .05);
+    box-shadow: -1px 0 0 hsla(0, 0%, 0%,.05);
 
     &.active {
       background-color: $cassiopeia-tabs-active-bg;
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .05) 100%);
+      background-image: linear-gradient(to bottom, hsla(0, 0%, 0%,0), hsla(0, 0%, 0%,.05) 100%);
       border-right: 0;
       border-left: 0;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
-      box-shadow: inset 2px 0 1px -1px rgba(0, 0, 0, .08), inset -2px 0 1px -1px rgba(0, 0, 0, .08), inset 0 1px 0 rgba(0, 0, 0, .02);
+      box-shadow: inset 2px 0 1px -1px hsla(0, 0%, 0%,.08), inset -2px 0 1px -1px hsla(0, 0%, 0%,.08), inset 0 1px 0 hsla(0, 0%, 0%,.02);
 
       &::after {
         position: absolute;
@@ -70,7 +70,7 @@
 
 .nav-tabs + .tab-content {
   padding: 15px;
-  background: $white-offset;
+  background: $white;
   border: 1px solid;
   border-color: $cassiopeia-border-color;
   border-radius: 0 0 $border-radius $border-radius;

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -60,7 +60,7 @@
     }
 
     &:focus {
-      box-shadow: 0 0 0 2px #00bcd4;
+      box-shadow: 0 0 0 2px hsl(187, 100%, 42%);
     }
   }
 
@@ -102,7 +102,7 @@
     margin-bottom: 0;
     margin-left: 8px;
     line-height: 1;
-    border-left: 1px solid #008fa1;
+    border-left: 1px solid hsl(187, 100%, 32%);
     opacity: .75;
 
     &:hover,
@@ -111,7 +111,7 @@
     }
 
     &::before {
-      color: #fff;
+      color: $white;
     }
   }
 }

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -76,32 +76,32 @@
   &[type="success"],
   &[type="message"] {
     --alert-accent-color: var(--success);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, .95);
     --alert-close-button: var(--success);
-    background-color: var(--white-offset);
+    background-color: var(--white);
   }
 
   &[type="info"],
   &[type="notice"] {
     --alert-accent-color: var(--info);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, .95);
     --alert-close-button: var(--info);
-    background-color: var(--white-offset);
+    background-color: var(--white);
   }
 
   &[type="warning"] {
     --alert-accent-color: var(--warning);
-    --alert-heading-text: #000;
-    --alert-close-button: #000;
-    background-color: var(--white-offset);
+    --alert-heading-text: $black;
+    --alert-close-button: $black;
+    background-color: var(--white);
   }
 
   &[type="error"],
   &[type="danger"] {
     --alert-accent-color: var(--danger);
-    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-heading-text: hsla(0, 0%, 100%, .95);
     --alert-close-button: var(--danger);
-    background-color: var(--white-offset);
+    background-color: var(--white);
   }
 
   .joomla-alert--close,

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -17,7 +17,7 @@
           top: 100%;
           z-index: 1001;
           min-width: 180px;
-          box-shadow: 0 0 10px rgba(0, 0, 0, .1);
+          box-shadow: 0 0 10px hsla(0, 0%, 0%, .1);
 
           @include media-breakpoint-down(md) {
             width: 100%;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR convert all colors currently used in branch development for template Cassiopeia from `rgb(a)` and `hex` to `hsl(a)`

Use of HSL colors are easier to understand than both `hex` and `rgb(a)`. See the list gray colors below.

```
$white:                              #fff;
$gray-100:                           #f8f9fa;
$gray-200:                           #e9ecef;
$gray-300:                           #dee2e6;
$gray-400:                           #ced4da;
$gray-500:                           #adb5bd;
$gray-600:                           #6c757d;
$gray-700:                           #495057;
$gray-800:                           #343a40;
$gray-900:                           #212529;
$black:                              #000;
```

will become

```
$white:                              hsl(0, 0%, 100%);
$gray-100:                           hsl(210, 17%, 98%);
$gray-200:                           hsl(210, 16%, 93%);
$gray-300:                           hsl(210, 14%, 89%);
$gray-400:                           hsl(210, 14%, 83%);
$gray-500:                           hsl(210, 11%, 71%);
$gray-600:                           hsl(208, 7%, 46%);
$gray-700:                           hsl(210, 9%, 31%);
$gray-800:                           hsl(210, 10%, 23%);
$gray-900:                           hsl(210, 11%, 15%);
$black:                              hsl(0, 0%, 0%);
```

### Testing Instructions

- Joomla 4 test
- checkout branch `development`
- `npm run build:css` 
- check colors on site
- apply patch
- `npm run build:css`
- check colors on site

Colors on site do not change. 
Only the code changes. 


Also merged color $white-offset into $white. Difference between both cannot be seen. And `hsl` sees them both as the same color. 