### PR TITLE
[RFC] Use Fontawesome icon for the dropdown toggle button for better visibility

### DIFF
--- a/templates/cassiopeia/html/mod_menu/metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/metismenu.php
@@ -97,7 +97,7 @@ if ($tagId = $params->get('tag_id', ''))
 	switch (true) :
 		// The next item is deeper.
 		case $item->deeper:
-			echo '<button class="has-arrow mm-collapsed mm-toggler" aria-expanded="false"><span class="sr-only">' . Text::_('JGLOBAL_TOGGLE_DROPDOWN') . '</span></button>';
+			echo '<button class="mm-collapsed mm-toggler" aria-expanded="false"><span class="sr-only">' . Text::_('JGLOBAL_TOGGLE_DROPDOWN') . '</span></button>';
 			echo '<ul class="mm-collapse">';
 			break;
 

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -71,23 +71,18 @@
         box-shadow: none;
 
         &:after {
-          width: .5em;
-          height: .5em;
-          content: "";
-          justify-self: flex-end;
-          border-color: currentColor;
-          border-style: solid;
-          border-width: 0 1px 1px 0;
+          font-family: "Font Awesome 5 Free";
+          font-size: 1.7em;
+          content: "\f0d7";
           transition: all .3s ease-out;
-          transform: rotate(45deg);
 
           @at-root .mm-active > & {
-            transform: rotate(-135deg);
+            transform: rotate(-180deg);
           }
         }
 
         &[aria-expanded="true"]:after {
-          transform: rotate(-135deg);
+          transform: rotate(-180deg);
         }
       }
     }

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -72,7 +72,6 @@
 
         &:after {
           font-family: "Font Awesome 5 Free";
-          font-size: 1.7em;
           content: "\f0d7";
           transition: all .3s ease-out;
 


### PR DESCRIPTION
Pull Request for Issue #74 .

### Summary of Changes

See title.

The RFC question is if we want to make our metismenu implementation be dependent on Fontawesome or not.

Someone might copy the template and then not want to use Fontawesome but use the metismenu.

On the other hand, other stuff like e.g. the search module's button also use Fontawesome, so it would need anyway some work on the template copy to get rid of Fontawesome.

Please give feedback with your opinion on this is a comment.

I desired I will try to make an alternative PR with another solution without Fontawesome.

### Testing Instructions

Checkout the development branch of this repository and apply the changes of this PR, or pull the branch of this PR into your local git clone.

Then run `npm ci`.

Then make a new installation and install blog sample data, if you haven't done that already.

Finally check the metismenu in frontend.

### Actual result BEFORE applying this Pull Request

![2020-09-16_1](https://user-images.githubusercontent.com/7413183/93330814-aa1e2b80-f81f-11ea-8ff4-baa804f49bb6.png)

![2020-09-16_2](https://user-images.githubusercontent.com/7413183/93330829-b1453980-f81f-11ea-988f-b52f0741bd2f.png)

![2020-09-16_3](https://user-images.githubusercontent.com/7413183/93330836-b4402a00-f81f-11ea-9f4a-81e8a0b5ff38.png)

### Expected result AFTER applying this Pull Request

![2020-09-16_4](https://user-images.githubusercontent.com/7413183/93334465-472f9300-f825-11ea-8778-9a1dce582c0b.png)

![2020-09-16_5](https://user-images.githubusercontent.com/7413183/93334473-4ac31a00-f825-11ea-9ebb-5570916f7246.png)

![2020-09-16_6](https://user-images.githubusercontent.com/7413183/93334487-4eef3780-f825-11ea-87fb-6f8eee133403.png)

### Documentation Changes Required

None.
