### PR TITLE
Change direction of background gradient for rtl

### DIFF
--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -18,10 +18,9 @@
     align-self: flex-end;
     height: 40px;
     padding: $cassiopeia-grid-gutter/2;
+    margin-left: auto;
     color: var(--cassiopeia-color-primary);
     background: $white;
     border-radius: $border-radius;
-
-    @include margin("left", auto);
   }
 }

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -46,6 +46,8 @@ dd {
 }
 
 .container-header {
+  background-image: $cassiopeia-header-grad-rtl;
+
   .container-nav .container-search:only-child {
     margin-right: auto;
     margin-left: 0;
@@ -113,4 +115,8 @@ dd {
 .btn-group > .btn:not(:first-child),
 .btn-group > .btn-group:not(:first-child) {
   @include border-right-radius(0);
+}
+
+.footer {
+  background-image: $cassiopeia-header-grad-rtl;
 }

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -119,4 +119,8 @@ dd {
 
 .footer {
   background-image: $cassiopeia-header-grad-rtl;
+  .back-top {
+    margin-right: auto;
+    margin-left: 0;
+  }
 }

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -4,6 +4,7 @@ $cassiopeia-border-color:             hsl(210, 14%, 89%) !default;
 $cassiopeia-box-shadow:               1px 1px 4px hsla(0, 0%, 0%, .1) !default;
 $cassiopeia-block-header-bg:          hsl(0, 0%, 96%) !default;
 $cassiopeia-header-grad:              linear-gradient(135deg, var(--cassiopeia-color-primary) 0%, var(--cassiopeia-color-hover) 100%);
+$cassiopeia-header-grad-rtl:          linear-gradient(135deg, var(--cassiopeia-color-hover) 0%, var(--cassiopeia-color-primary) 100%);
 
 // Standard
 $standard-color-primary:              hsl(220, 67%, 20%);


### PR DESCRIPTION
Pull Request for Issue #88  .

### Summary of Changes
Change direction of background gradient


### Testing Instructions
Run npm ci


### Expected result
The background gradient in header and footer goes from dark on the right to light on the left


### Actual result
The background gradient in header and footer goes from dark on the left to light on the right


