### PR TITLE
Improve error and offline pages

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -74,21 +74,6 @@ else
 	$logo = '<img src="' . $this->baseurl . '/templates/' . $this->template . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
 
-// Header bottom margin
-$headerMargin = !$this->countModules('banner') ? ' mb-4' : '';
-
-$hasClass = '';
-
-if ($this->countModules('sidebar-left'))
-{
-	$hasClass .= ' has-sidebar-left';
-}
-
-if ($this->countModules('sidebar-right'))
-{
-	$hasClass .= ' has-sidebar-right';
-}
-
 // Container
 $wrapper = $params->get('fluidContainer') ? 'wrapper-fluid' : 'wrapper-static';
 
@@ -102,17 +87,16 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	<jdoc:include type="scripts" />
 </head>
 
-<body class="site-grid site <?php echo $option
+<body class="site-grid site error_site <?php echo $option
 	. ' ' . $wrapper
 	. ' view-' . $view
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
-	. ' ' . $pageclass
-	. $hasClass;
+	. ' ' . $pageclass;
 	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
-	<header class="header container-header full-width <?php echo $headerMargin; ?>">
+	<header class="header container-header full-width">
 		<div class="grid-child">
 			<div class="navbar-brand">
 				<a href="<?php echo $this->baseurl; ?>/">
@@ -146,93 +130,49 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 		<?php endif; ?>
 	</header>
 
-	<?php if ($this->countModules('banner')) : ?>
-		<div class="container-banner full-width">
-			<jdoc:include type="modules" name="banner" style="none" />
-		</div>
-	<?php endif; ?>
-
-	<?php if ($this->countModules('top-a')) : ?>
-	<div class="grid-child container-top-a">
-		<jdoc:include type="modules" name="top-a" style="cardGrey" />
-	</div>
-	<?php endif; ?>
-
-	<?php if ($this->countModules('top-b')) : ?>
-	<div class="grid-child container-top-b">
-		<jdoc:include type="modules" name="top-b" style="card" />
-	</div>
-	<?php endif; ?>
-
-	<?php if ($this->countModules('sidebar-left')) : ?>
-		<div class="grid-child container-sidebar-left">
-			<jdoc:include type="modules" name="sidebar-left" style="default" />
-		</div>
-	<?php endif; ?>
-
 	<div class="grid-child container-component">
-		<div class="mt-3">
-			<h1 class="page-header"><?php echo Text::_('JERROR_LAYOUT_PAGE_NOT_FOUND'); ?></h1>
-			<div class="card">
-				<div class="card-body">
-					<jdoc:include type="message" />
-					<p><strong><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></strong></p>
-					<p><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></p>
-					<ul>
-						<li><?php echo Text::_('JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE'); ?></li>
-						<li><?php echo Text::_('JERROR_LAYOUT_MIS_TYPED_ADDRESS'); ?></li>
-						<li><?php echo Text::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
-						<li><?php echo Text::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
-					</ul>
-					<p><?php echo Text::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?></p>
-					<p><a href="<?php echo $this->baseurl; ?>/index.php" class="btn btn-secondary"><span class="fas fa-home" aria-hidden="true"></span> <?php echo Text::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></p>
-					<hr>
-					<p><?php echo Text::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
-					<blockquote>
-						<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
-					</blockquote>
-					<?php if ($this->debug) : ?>
-						<div>
-							<?php echo $this->renderBacktrace(); ?>
-							<?php // Check if there are more Exceptions and render their data as well ?>
-							<?php if ($this->error->getPrevious()) : ?>
-								<?php $loop = true; ?>
-								<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-								<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
-								<?php $this->setError($this->_error->getPrevious()); ?>
-								<?php while ($loop === true) : ?>
-									<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-									<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
-									<?php echo $this->renderBacktrace(); ?>
-									<?php $loop = $this->setError($this->_error->getPrevious()); ?>
-								<?php endwhile; ?>
-								<?php // Reset the main error object to the base error ?>
-								<?php $this->setError($this->error); ?>
-							<?php endif; ?>
-						</div>
-					<?php endif; ?>
-				</div>
+		<h1 class="page-header"><?php echo Text::_('JERROR_LAYOUT_PAGE_NOT_FOUND'); ?></h1>
+		<div class="card">
+			<div class="card-body">
+				<jdoc:include type="message" />
+				<p><strong><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></strong></p>
+				<p><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></p>
+				<ul>
+					<li><?php echo Text::_('JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE'); ?></li>
+					<li><?php echo Text::_('JERROR_LAYOUT_MIS_TYPED_ADDRESS'); ?></li>
+					<li><?php echo Text::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
+					<li><?php echo Text::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
+				</ul>
+				<p><?php echo Text::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?></p>
+				<p><a href="<?php echo $this->baseurl; ?>/index.php" class="btn btn-secondary"><span class="fas fa-home" aria-hidden="true"></span> <?php echo Text::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></p>
+				<hr>
+				<p><?php echo Text::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
+				<blockquote>
+					<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+				</blockquote>
+				<?php if ($this->debug) : ?>
+					<div>
+						<?php echo $this->renderBacktrace(); ?>
+						<?php // Check if there are more Exceptions and render their data as well ?>
+						<?php if ($this->error->getPrevious()) : ?>
+							<?php $loop = true; ?>
+							<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
+							<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+							<?php $this->setError($this->_error->getPrevious()); ?>
+							<?php while ($loop === true) : ?>
+								<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
+								<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+								<?php echo $this->renderBacktrace(); ?>
+								<?php $loop = $this->setError($this->_error->getPrevious()); ?>
+							<?php endwhile; ?>
+							<?php // Reset the main error object to the base error ?>
+							<?php $this->setError($this->error); ?>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
 			</div>
 		</div>
 	</div>
-
-	<?php if ($this->countModules('sidebar-right')) : ?>
-	<div class="grid-child container-sidebar-right">
-		<jdoc:include type="modules" name="sidebar-right" style="default" />
-	</div>
-	<?php endif; ?>
-
-	<?php if ($this->countModules('bottom-a')) : ?>
-	<div class="grid-child container-bottom-a">
-		<jdoc:include type="modules" name="bottom-a" style="cardGrey" />
-	</div>
-	<?php endif; ?>
-
-	<?php if ($this->countModules('bottom-b')) : ?>
-	<div class="grid-child container-bottom-b">
-		<jdoc:include type="modules" name="bottom-b" style="card" />
-	</div>
-	<?php endif; ?>
 
 	<?php if ($this->countModules('footer') || ($params->get('backTop') == 1)) : ?>
 	<footer class="container-footer footer full-width">

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -32,7 +32,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 $params = $app->getTemplate(true)->params;
 
 // Template path
-$templatePath = 'templates/' . $this->template;
+$templatePath = Uri::root() .'templates/' . $this->template;
 
 // Color Theme
 $paramsColorName = $params->get('colorName', 'colors_standard');
@@ -61,17 +61,17 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);
 
 // Logo file or site title param
-if ($params->get('logoFile'))
+if ($this->params->get('logoFile'))
 {
-	$logo = '<img src="' . Uri::root() . $params->get('logoFile') . '" alt="' . $sitename . '">';
+	$logo = '<img src="' . Uri::root() . htmlspecialchars($params->get('logoFile'), ENT_QUOTES) . '" alt="' . $sitename . '">';
 }
-elseif ($params->get('siteTitle'))
+elseif ($this->params->get('siteTitle'))
 {
 	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
 }
 else
 {
-	$logo = '<img src="' . $this->baseurl . '/templates/' . $this->template . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
+	$logo = '<img src="' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
 
 // Container

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -32,7 +32,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 $params = $app->getTemplate(true)->params;
 
 // Template path
-$templatePath = Uri::root() .'templates/' . $this->template;
+$templatePath = 'templates/' . $this->template;
 
 // Color Theme
 $paramsColorName = $params->get('colorName', 'colors_standard');
@@ -71,7 +71,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = '<img src="' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
+	$logo = '<img src="' . $this->baseurl . '/' . $templatePath. '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
 
 // Container

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -24,6 +24,26 @@ $wa               = $this->getWebAssetManager();
 
 $fullWidth = 1;
 
+// Template path
+$templatePath = 'templates/' . $this->template;
+
+// Color Theme
+$paramsColorName = $this->params->get('colorName', 'colors_standard');
+$assetColorName  = 'theme.' . $paramsColorName;
+$wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
+$this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
+
+// Use a font scheme if not "None" is set in the template style options
+$paramsFontScheme = $this->params->get('useFontScheme', 'fonts-local_roboto');
+
+if ($paramsFontScheme)
+{
+	// Preload the stylesheet for the font scheme, actually we need to preload the font(s)
+	$assetFontScheme  = 'fontscheme.' . $paramsFontScheme;
+	$wa->registerAndUseStyle($assetFontScheme, $templatePath . '/css/global/' . $paramsFontScheme . '.css');
+	$this->getPreloadManager()->preload($wa->getAsset('style', $assetFontScheme)->getUri(), ['as' => 'style']);
+}
+
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.offline')
@@ -39,16 +59,17 @@ $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 
 if ($this->params->get('logoFile'))
 {
-	$logo = '<img src="' . Uri::root() . $this->params->get('logoFile') . '" alt="' . $sitename . '">';
+	$logo = '<img src="' . Uri::root() . htmlspecialchars($this->params->get('logoFile'), ENT_QUOTES) . '" alt="' . $sitename . '">';
 }
 elseif ($this->params->get('siteTitle'))
 {
-	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($this->params->get('siteTitle')) . '</span>';
+	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($this->params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
 }
 else
 {
-	$logo = '<span class="site-title">' . $sitename . '</span>';
+	$logo = '<img src="' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -4,6 +4,9 @@
 
 .error_site {
   height: 100vh;
+  .page-header {
+    margin-top: $cassiopeia-grid-gutter;
+  }
 }
 
 // com_modules

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -1,5 +1,11 @@
 // Modifiers
 
+// error page
+
+.error_site {
+  height: 100vh;
+}
+
 // com_modules
 [class^="container-"],
 [class*=" container-"] {

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -4,20 +4,11 @@
 // Variables, Functions and Mixins
 @import "tools/tools";
 
-html {
-  background: radial-gradient(circle, $gray-100, $gray-200);
-  background-color: $cyan;
-  background-image: none;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-}
-
 body {
   padding: 0;
   margin: 0;
-  font: 14px / 18px sans-serif;
+  font-size: $font-size-root;
   color: $gray-700;
-  background-color: transparent;
 }
 
 .outer {
@@ -35,7 +26,7 @@ body {
 .offline-card {
   width: 100%;
   max-width: 30em;
-  margin: 0 auto 60px;
+  margin: 60px auto;
   background-color: $white;
   border: 1px solid hsla(0, 0%, 0%,.1);
   border-radius: 5px;
@@ -44,26 +35,22 @@ body {
 
 .header {
   position: relative;
-  padding-top: 25px;
-  padding-bottom: 35px;
+  padding: $cassiopeia-grid-gutter ($cassiopeia-grid-gutter*2);
   margin: 0;
+  color: $white;
   text-align: center;
+  background-color: var(--cassiopeia-color-primary);
+  background-image: $cassiopeia-header-grad;
   border-radius: 5px 5px 0 0;
+
+  [dir=rtl] & {
+    background-image: $cassiopeia-header-grad-rtl;
+  }
+
 }
 
 html[dir=rtl] .header {
   border-radius: 5px 0 0 5px;
-}
-
-.header::after {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  left: 0;
-  height: 3px;
-  content: "";
-  background-color: hsl(199, 100%, 36%);
-  background-image: linear-gradient(to right, hsl(209, 100%, 67%) 0%, hsl(193, 100%, 67%) 100%);
 }
 
 .login {

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -4,13 +4,6 @@
 // Variables, Functions and Mixins
 @import "tools/tools";
 
-body {
-  padding: 0;
-  margin: 0;
-  font-size: $font-size-root;
-  color: $gray-700;
-}
-
 .outer {
   position: relative;
   display: flex;


### PR DESCRIPTION
Pull Request for Issue #100 .

### Summary of Changes

- Make template parameters work on error.php
- Remove all module positions (only menu, search and footer left)
- Adapt layout of offline.php to Cassiopeia design

### Testing Instructions
Run npm ci

### Expected result
![image](https://user-images.githubusercontent.com/9153168/93893968-81e66f00-fcee-11ea-8c9e-2d3633f69940.png)

### Actual result
![image](https://user-images.githubusercontent.com/9153168/93894113-a80c0f00-fcee-11ea-96a8-b99638a9ea8c.png)

(Grid was messed up, see https://github.com/joomla/joomla-cms/issues/30023 , menu as hamburger only, no logo, no colors)
