### PR TITLE
moving layout styling from grid to layout. Fix spacing above message box

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -9,7 +9,6 @@
   width: 100%;
   min-width: 16rem;
   padding: 0;
-  margin-bottom: 1rem;
   color: var(--atum-text-dark);
   background-color: var(--white);
   border: 1px solid var(--alert-accent-color, transparent);

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -9,6 +9,7 @@
   width: 100%;
   min-width: 16rem;
   padding: 0;
+  margin-bottom: 1rem;
   color: var(--atum-text-dark);
   background-color: var(--white);
   border: 1px solid var(--alert-accent-color, transparent);

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -23,17 +23,6 @@
       max-width: none;
     }
 
-    .container-component,
-    .container-sidebar-left,
-    .container-sidebar-right {
-      display: flex;
-      flex-direction: column;
-
-      > * + * {
-        margin-top: $cassiopeia-grid-gutter;
-      }
-    }
-
     &:not(.has-sidebar-left) .container-component {
       grid-column-start: main-start;
     }
@@ -89,26 +78,16 @@
   grid-area: top-b;
 }
 
-.container-main {
-  grid-area: main;
-}
-
 .container-component {
   grid-area: comp;
 }
 
 .container-sidebar-left {
   grid-area: side-l;
-  .sidebar-left:first-child {
-    margin-top: $cassiopeia-grid-gutter;
-  }
 }
 
 .container-sidebar-right {
   grid-area: side-r;
-  .sidebar-right:first-child {
-    margin-top: $cassiopeia-grid-gutter;
-  }
 }
 
 .container-main-top {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -32,6 +32,7 @@
 .container-bottom-a,
 .container-bottom-b {
   padding: 4rem 0;
+
   > * {
     flex: 1;
     margin: ($cassiopeia-grid-gutter / 2);
@@ -46,29 +47,23 @@
   }
 }
 
-.container-main {
-  > * {
-    margin: ($cassiopeia-grid-gutter / 2);
-  }
-
-  @include media-breakpoint-down(sm) {
-    flex-direction: column;
-
-    > * {
-      flex: 0 1 auto;
-    }
-  }
-}
-
-.container-component {
+.container-component,
+.container-sidebar-left,
+.container-sidebar-right {
+  display: flex;
+  flex-direction: column;
   flex: 1;
 
-  > *:not(#system-message-container) {
-    margin-bottom: $cassiopeia-grid-gutter;
+  > * {
+    margin-bottom: 0;
 
-    &:last-of-type {
-      margin-bottom: 0;
+    &:first-child {
+      margin-top: $cassiopeia-grid-gutter;
     }
+  }
+
+  > * + * {
+    margin-top: $cassiopeia-grid-gutter;
   }
 }
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -16,7 +16,7 @@
   border-radius: .25rem;
   transition: opacity .15s linear;
 
-  + joomla-alert {
+  + * {
     margin-top: 1rem;
   }
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -9,12 +9,16 @@
   width: 100%;
   min-width: 16rem;
   padding: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   color: var(--gray-dark);
   background-color: $white;
   border: 1px solid var(--alert-accent-color, transparent);
   border-radius: .25rem;
   transition: opacity .15s linear;
+
+  + joomla-alert {
+    margin-top: 1rem;
+  }
 
   .alert-heading {
     display: flex;


### PR DESCRIPTION
Pull Request for Issue #115 .

### Summary of Changes

- Moves layout styling from grid.scss to layout.scss
- Apply margin-top to first child of .container-component, .container-sidebar-left and .container-sidebar-right
- Added `display:none` on `system-message:empty`. To get this working I've created https://github.com/joomla/joomla-cms/pull/30760 to change start and closing of `<?php ?>` in order to remove obsolete spacing. 

### Testing Instructions

Repeat changes stated in #115

### Expected result

<img width="1348" alt="Schermafbeelding 2020-09-25 om 08 32 36" src="https://user-images.githubusercontent.com/639822/94234318-c00baa80-ff09-11ea-8a6a-b7c63d6597d3.png">


### Actual result

as shown in #115

### ALERT

Please have a look at https://github.com/joomla/joomla-cms/pull/30760
It will solve the obsolete spacing above the alert when no alert has to be shown. 

<img width="1346" alt="Schermafbeelding 2020-09-25 om 08 27 16" src="https://user-images.githubusercontent.com/639822/94234311-bda95080-ff09-11ea-8e99-e410ee422679.png">

