### PR TITLE
link in the footer "author-login" as alias

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -673,21 +673,23 @@ class PlgSampledataBlog extends CMSPlugin
 			return $response;
 		}
 
-		// Insert level 1.
+		// Insert level 1 (Link in the footer as alias)
 		$menuItems = array(
-			// Author Login
 			array(
 				'menutype'     => $menuTypes[2],
 				'title'        => Text::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_8_TITLE'),
-				'link'         => 'index.php?option=com_users&view=login',
-				'component_id' => ExtensionHelper::getExtensionRecord('com_users', 'component')->extension_id,
+				'link'         => 'index.php?Itemid=',
+				'type'         => 'alias',
 				'params'       => array(
-					'login_redirect_url'     => 'index.php?Itemid=' . $menuIdsLevel1[0],
-					'logindescription_show'  => 1,
-					'logoutdescription_show' => 1,
-					'menu_text'              => 1,
-					'show_page_heading'      => 0,
-					'secure'                 => 0,
+					'aliasoptions'      => $menuIdsLevel1[2],
+					'alias_redirect'    => 0,
+					'menu-anchor_title' => '',
+					'menu-anchor_css'   => '',
+					'menu_image'        => '',
+					'menu_image_css'    => '',
+					'menu_text'         => 1,
+					'menu_show'         => 1,
+					'secure'            => 0,
 				),
 			),
 		);


### PR DESCRIPTION
Pull Request for Issue #127

### Summary of Changes
Make the Link "Author Login" in the footer an alias for the Link "Author Login" in the main-menu-blog.


### Testing Instructions
On a fresh Installation, install blog sample data. 


### Expected result
The Link in the Bottom now is an alias for the "Author Login" in the Blog Menu. 


### Actual result
The link in the Bottom to "Author Login" is a second link to with the same taget as the first one.


### Documentation Changes Required
no
