### PR TITLE
Change colours of edit module icons in header and footer area

### DIFF
--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -1,7 +1,15 @@
 // Frontend Editing
 
-.jmodedit {
+.btn.jmodedit {
   position: absolute;
   top: 10px;
   right: 10px;
+}
+header, footer {
+  .btn.jmodedit {
+    color: $white;
+    &:hover {
+      color: $gray-300;
+    }
+  }
 }

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -9,8 +9,5 @@
 header, footer {
   .btn.jmodedit {
     color: $white;
-    &:hover {
-      color: $gray-300;
-    }
   }
 }

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -5,6 +5,7 @@
   top: 10px;
   right: 10px;
 }
+
 header, footer {
   .btn.jmodedit {
     color: $white;


### PR DESCRIPTION
Pull Request for Issue #139 .

### Summary of Changes
Edit button color white for header and footer


### Testing Instructions
Run npm ci or compile scss


### Expected result
The edit icons for modules on header and footer area are visible


