### PR TITLE
Change rules for active and hover menu items

### DIFF
--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -128,6 +128,15 @@
         left: 0;
         background: $white;
       }
+
+      @include media-breakpoint-down(md) {
+        &.active > a,
+        &.active > span,
+        > a:hover,
+        > span:hover {
+          text-decoration: underline;
+        }
+      }
     }
 
     .parent {

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -294,20 +294,25 @@
   }
 }
 
-.mod-menu.nav {
-  li {
-    padding: ($cassiopeia-grid-gutter/2) 0;
+:not(.container-header) {
+  .mod-menu.nav {
+    li {
+      padding: ($cassiopeia-grid-gutter/2) 0;
 
-    a {
-      text-decoration: none;
-    }
+      a {
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
 
-    &.active > a {
-      text-decoration: underline;
-    }
+      &.active > a {
+        text-decoration: underline;
+      }
 
-    .mod-menu__sub {
-      padding-left: $cassiopeia-grid-gutter;
+      .mod-menu__sub {
+        padding-left: $cassiopeia-grid-gutter;
+      }
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue #126 .

### Summary of Changes
Changed the rules for active and hover menu items in mobile view and in menus outside header position.

### Testing Instructions
Run npm ci


### Expected result
Active menu items are underlined in mobile view

### Actual result
No visual indicator for active menu item in mobile view