### PR TITLE
Change spacing of sidebar modules

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -99,16 +99,10 @@
 
 .container-sidebar-left {
   grid-area: side-l;
-  .sidebar-left:first-child {
-    margin-top: $cassiopeia-grid-gutter;
-  }
 }
 
 .container-sidebar-right {
   grid-area: side-r;
-  .sidebar-right:first-child {
-    margin-top: $cassiopeia-grid-gutter;
-  }
 }
 
 .container-main-top {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -84,6 +84,23 @@
   }
 }
 
+.container-sidebar-left {
+  .sidebar-left:first-child {
+    margin-top: $cassiopeia-grid-gutter;
+  }
+  .sidebar-left:last-child {
+    margin-bottom: $cassiopeia-grid-gutter;
+  }
+}
+.container-sidebar-right {
+  .sidebar-right:first-child {
+    margin-top: $cassiopeia-grid-gutter;
+  }
+  .sidebar-right:last-child {
+    margin-bottom: $cassiopeia-grid-gutter;
+  }
+}
+
 .system-debug {
   display: block;
 }


### PR DESCRIPTION
Pull Request for Issue #134 .

### Summary of Changes
Move sidebar definition from _css-grid.scss to _layout.scss
Add margin-bottom for last element on sidebar


### Testing Instructions
Run npm ci

### Expected result
The last element on the sidebar is not truncated, there is a margin bottom (more visible if footer not present)


### Actual result
The last element is truncated, no space below.

