### PR TITLE
Revert body color to bootstrap standard

### DIFF
--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -91,9 +91,6 @@ $theme-colors: (
   dark: $dark
 );
 
-// Body
-$body-color:                          var(--cassiopeia-color-primary);
-
 // Links
 $link-color:                          var(--cassiopeia-color-link);
 $link-hover-color:                    var(--cassiopeia-color-hover);


### PR DESCRIPTION
Revert body color to bootstrap standard, no --color-cassiopeia-primary