### PR TITLE
Fix #30795 layout cloud for tags modules 

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -263,6 +263,11 @@
 
 // Modules
 
+.tag {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .breadcrumb {
   background-color: hsla(0, 0%, 0%, .03);
 }


### PR DESCRIPTION
Pull Request for Issue  https://github.com/joomla/joomla-cms/issues/30795

### Summary of Changes
This pr avoids wrapping a tag, consiting of name and badge.


### Testing Instructions
Edit an article and add some tags, longer and shorter names. 
Make a module "poular tags" with layout cloud.

### Expected result
Tags and thei badges are kept together, also if a line breaks 


### Actual result
see https://github.com/joomla/joomla-cms/issues/30795

