### PR TITLE
Correct underline for menu on header

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -302,31 +302,21 @@
       text-decoration: none;
       &:hover {
         text-decoration: underline;
+        @at-root .container-header & {
+          text-decoration: none;
+        }
       }
     }
 
     &.active > a {
       text-decoration: underline;
+      @at-root .container-header & {
+        text-decoration: none;
+      }
     }
 
     .mod-menu__sub {
       padding-left: $cassiopeia-grid-gutter;
-    }
-  }
-}
-
-.container-header {
-  .mod-menu.nav {
-    li {
-      a {
-        &:hover {
-          text-decoration: none;
-        }
-      }
-
-      &.active > a {
-        text-decoration: none;
-      }
     }
   }
 }

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -300,8 +300,10 @@
 
     a {
       text-decoration: none;
+      
       &:hover {
         text-decoration: underline;
+        
         @at-root .container-header & {
           text-decoration: none;
         }
@@ -310,6 +312,7 @@
 
     &.active > a {
       text-decoration: underline;
+      
       @at-root .container-header & {
         text-decoration: none;
       }

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -294,24 +294,38 @@
   }
 }
 
-:not(.container-header) {
+.mod-menu.nav {
+  li {
+    padding: ($cassiopeia-grid-gutter/2) 0;
+
+    a {
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    &.active > a {
+      text-decoration: underline;
+    }
+
+    .mod-menu__sub {
+      padding-left: $cassiopeia-grid-gutter;
+    }
+  }
+}
+
+.container-header {
   .mod-menu.nav {
     li {
-      padding: ($cassiopeia-grid-gutter/2) 0;
-
       a {
-        text-decoration: none;
         &:hover {
-          text-decoration: underline;
+          text-decoration: none;
         }
       }
 
       &.active > a {
-        text-decoration: underline;
-      }
-
-      .mod-menu__sub {
-        padding-left: $cassiopeia-grid-gutter;
+        text-decoration: none;
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue #162 .

### Summary of Changes
Changed rules for **non-metismenu** on menu position (header)


### Testing Instructions
Run npm


### Expected result
No double underline on menu items when hovered for **non-metismenu** on position menu (header) 


### Actual result
Double underline

