### PR TITLE
Fix missing css variable values for font scheme "None" and make "None" the default scheme

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -41,7 +41,7 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if not "None" is set in the template style options
-$paramsFontScheme = $params->get('useFontScheme', 'fonts-local_roboto');
+$paramsFontScheme = $params->get('useFontScheme', false);
 
 if ($paramsFontScheme)
 {

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -38,7 +38,7 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if not "None" is set in the template style options
-$paramsFontScheme = $this->params->get('useFontScheme', 'fonts-local_roboto');
+$paramsFontScheme = $this->params->get('useFontScheme', false);
 
 if ($paramsFontScheme)
 {

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -34,7 +34,7 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $this->getPreloadManager()->preload($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if not "None" is set in the template style options
-$paramsFontScheme = $this->params->get('useFontScheme', 'fonts-local_roboto');
+$paramsFontScheme = $this->params->get('useFontScheme', false);
 
 if ($paramsFontScheme)
 {

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -19,8 +19,8 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--cassiopeia-font-family-headings);
-  font-weight: var(--cassiopeia-font-weight-headings);
+  font-family: var(--cassiopeia-font-family-headings, "Helvetica Neue", Helvetica, Arial, sans-serif);
+  font-weight: var(--cassiopeia-font-weight-headings, 700);
 }
 
 a {

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -19,7 +19,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--cassiopeia-font-family-headings, "Helvetica Neue", Helvetica, Arial, sans-serif);
+  font-family: var(--cassiopeia-font-family-headings, $font-family-sans-serif);
   font-weight: var(--cassiopeia-font-weight-headings, 700);
 }
 

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -20,7 +20,7 @@ h4,
 h5,
 h6 {
   font-family: var(--cassiopeia-font-family-headings, $font-family-sans-serif);
-  font-weight: var(--cassiopeia-font-weight-headings, 700);
+  font-weight: var(--cassiopeia-font-weight-headings, $font-weight-bold);
 }
 
 a {

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -132,7 +132,7 @@ $metismenu:                           true !default;
 $cassiopeia-toolbar-line-height:      1.8rem;
 
 // Typography
-$font-family-base:                    var(--cassiopeia-font-family-body);
+$font-family-base:                    var(--cassiopeia-font-family-body, "Helvetica Neue", Helvetica, Arial, sans-serif);
 
 $font-size-root:                      calc(1em + .16vw);
 $font-size-lg:                        1.25rem;

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -132,7 +132,8 @@ $metismenu:                           true !default;
 $cassiopeia-toolbar-line-height:      1.8rem;
 
 // Typography
-$font-family-base:                    var(--cassiopeia-font-family-body, "Helvetica Neue", Helvetica, Arial, sans-serif);
+$font-family-sans-serif:             -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$font-family-base:                    var(--cassiopeia-font-family-body, $font-family-sans-serif);
 
 $font-size-root:                      calc(1em + .16vw);
 $font-size-lg:                        1.25rem;

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -73,7 +73,7 @@
 					name="useFontScheme"
 					type="groupedlist"
 					label="TPL_CASSIOPEIA_FONT_LABEL"
-					default="fonts-local_roboto"
+					default="0"
 					>
 					<option value="0">JNONE</option>
 					<group label="TPL_CASSIOPEIA_FONT_GROUP_LOCAL">


### PR DESCRIPTION
Pull Request for Issue #129 (partly) .

### Summary of Changes

This pull request (PR) changes 2 things.

1. When the font scheme is set to `None` in Cassiopeia template style settings, the css variables `--cassiopeia-font-family-body`, `--cassiopeia-font-family-headings` and `--cassiopeia-font-weight-headings` are not set because there is no additional css file loaded which defines these values, like it is done with other font schemes.
This results in `font-family` being just `sans-serif` for headings and body and the bold font weight `700` not being applied to the headings when font scheme is set to `None`.
This PR corrects it by using the same font-family definition as bootstrap 4 does for the default values of these css variables:
`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`

2. Because the default font scheme should be safe regarding privacy aspects (e.g. GDPR), we had chosen the local Rototo font as default.
But this font has by far larger font files than when you load the same font from Google Fonts in web, because the local font files combine all available character sets into one file.
This might be a page speed issue, see discussion in issue #129 .
This PR solves it by chosing "None" as default value, which is safe regarding privacy **_and_** optimal for page speed.

### Testing Instructions

#### Test 1 - Reproduce the issue

1. Checkout the development branch of this repository, run `composer install` and `npm ci` and then make a new installation.
If you don't have a git client and composer and npm, make a new installation using the following installation package:
[https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_2020-10-02_v3.zip](https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_2020-10-02_v3.zip)
It's the same package as linked in the testing instructions of PR #48 .
2. Login to backend and install blog sample data.
3. Go to the "Advanced" tab of the Cassiopeia template style options and check the value of the Font Scheme field.
Result: It is "Roboto (local)".
4. Change the Font Scheme to "None" and save the changes.
5. On any frontend page, inspect some body text and some heading with the developer tools of your browser. Check the font-family and in case of headings also font-weight. For both, check which assignment is used and which value is applied at the end.

Result: See section "Actual result BEFORE applying this Pull Request" below.

#### Test 2 - Check the fix of this PR

1. Apply the changes of this PR on your git client and run `npm ci` and then make a new installation.
If you don't have a git client and npm, make a new installation using the following installation package:
[https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_PR-166_2020-10-02_v1.zip](https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_PR-166_2020-10-02_v1.zip)
2. Login to backend and install blog sample data.
3. Go to the "Advanced" tab of the Cassiopeia template style options and check the value of the Font Scheme field.
Result: It is "None".
4. On any frontend page, inspect some body text and some heading with the developer tools of your browser. Check the font-family and in case of headings also font-weight. For both, check which assignment is used and which value is applied at the end.

Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

The default font scheme on new installations is `Roboto (local)`.

For body text, the CSS variable `--cassiopeia-font-family-body` shall be used as font-family, see orange frame in the following screenshot.

But when font scheme "None" is selected for the template style, it ends with just `sans-serif` being used because the CSS variable is not set, see red frame in the screenshot:

![2020-10-02_4](https://user-images.githubusercontent.com/7413183/94959071-de1c7080-04f0-11eb-84ee-c19edba82a49.png)

For headings, the CSS variable `--cassiopeia-font-family-headings` shall be used as font-family and `--cassiopeia-font-weight-headings` as font-weight, see orange frame in the following screenshot.

But when font scheme "None" is selected for the template style, it ends with just `sans-serif` being used as font-family, and the font-weight is the 400 from inherited from the body instead of 700 as it should be, because the CSS variables are not set, see red frames in the screenshot:

![2020-10-02_5](https://user-images.githubusercontent.com/7413183/94959096-e5437e80-04f0-11eb-8a82-a347962da758.png)

### Expected result AFTER applying this Pull Request

The default font scheme on new installations is `None`.

When font scheme "None" is selected for the template style, the font-family is `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"` for body text, see green frame in the following screenshot:

![2020-10-02_6](https://user-images.githubusercontent.com/7413183/94959121-ef657d00-04f0-11eb-8e45-50d4c0fd069b.png)

Also with font scheme "None", the font-family for headings is as mentioned before for body text, and the font weight is 700, see green frames in the following screenshot:

![2020-10-02_7](https://user-images.githubusercontent.com/7413183/94959130-f3919a80-04f0-11eb-9f5f-e35c3a0f5cfb.png)

### Documentation Changes Required

None.