### PR TITLE
move backToTop outside of footer and apply styling

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -195,18 +195,20 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('footer') || ($this->params->get('backTop') == 1)) : ?>
+	<?php if ($this->countModules('footer')) : ?>
 	<footer class="container-footer footer full-width">
 		<div class="grid-child">
 			<jdoc:include type="modules" name="footer" style="none" />
-			<?php if ($this->params->get('backTop') == 1) : ?>
-				<a href="#top" id="back-top" class="back-top">
-					<span class="fas fa-arrow-up" aria-hidden="true"></span>
-					<span class="sr-only"><?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?></span>
-				</a>
-			<?php endif; ?>
 		</div>
 	</footer>
+	<?php endif; ?>
+
+	<?php if ($this->params->get('backTop') == 1) : ?>
+		<div class="back-to-top-wrapper">
+			<a href="#top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
+				<span class="fas fa-arrow-up fa-fw" aria-hidden="true"></span>
+			</a>
+		</div>
 	<?php endif; ?>
 
 	<jdoc:include type="modules" name="debug" style="none" />

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -3,11 +3,10 @@
 * inspired by https://moderncss.dev/pure-css-smooth-scroll-back-to-top/
 */
 $scrollLength: 100vh;
-$linkOffset: 5rem;
 
 .back-to-top-wrapper {
   position: absolute;
-  top: calc(#{$scrollLength} + #{$linkOffset});
+  top: calc(#{$scrollLength} + #{$cassiopeia-grid-gutter * 10});
   right: $cassiopeia-grid-gutter;
   bottom: 0;
   width: 2.25rem;
@@ -23,7 +22,7 @@ $linkOffset: 5rem;
   position: fixed;
   position: sticky;
   pointer-events: all;
-  top: calc(#{$scrollLength} - #{$linkOffset});
+  top: calc(#{$scrollLength} - #{$cassiopeia-grid-gutter * 3});
   padding: $cassiopeia-grid-gutter/2;
   color: var(--cassiopeia-color-primary, $standard-color-primary);
   background-color: var(--white, $white);

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -9,7 +9,7 @@ $scrollLength: 100vh;
   top: calc(#{$scrollLength} + #{$cassiopeia-grid-gutter * 10});
   right: $cassiopeia-grid-gutter;
   bottom: 0;
-  width: 2.25rem;
+  width: 3rem;
   pointer-events: none;
 
   [dir=rtl] & {

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -1,0 +1,39 @@
+/**
+* Back to Top
+* inspired by https://moderncss.dev/pure-css-smooth-scroll-back-to-top/
+*/
+$scrollLength: 100vh;
+$linkOffset: 5rem;
+
+.back-to-top-wrapper {
+  position: absolute;
+  top: calc(#{$scrollLength} + #{$linkOffset});
+  right: $cassiopeia-grid-gutter;
+  bottom: 0;
+  width: 2.25rem;
+  pointer-events: none;
+
+  @at-root [dir=rtl] & {
+    right: unset;
+    left: $cassiopeia-grid-gutter;
+  }
+}
+
+.back-to-top-link {
+  position: fixed;
+  position: sticky;
+  pointer-events: all;
+  top: calc(#{$scrollLength} - #{$linkOffset});
+  padding: $cassiopeia-grid-gutter/2;
+  color: var(--cassiopeia-color-primary, $standard-color-primary);
+  background-color: var(--white, $white);
+  border: 1px solid transparent;
+  border-radius: $border-radius;
+  transition: border-color 200ms ease-in;
+
+  &:hover,
+  &:focus {
+    color: var(--cassiopeia-color-hover);
+    border-color: var(--cassiopeia-color-primary, $standard-color-primary);
+  }
+}

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -13,7 +13,7 @@ $linkOffset: 5rem;
   width: 2.25rem;
   pointer-events: none;
 
-  @at-root [dir=rtl] & {
+  [dir=rtl] & {
     right: unset;
     left: $cassiopeia-grid-gutter;
   }

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -14,22 +14,7 @@
     color: currentColor;
   }
 
-  .back-top {
-    align-self: flex-end;
-    height: 40px;
-    padding: $cassiopeia-grid-gutter/2;
-    margin-left: auto;
-    color: var(--cassiopeia-color-primary);
-    background: $white;
-    border-radius: $border-radius;
-  }
-
   [dir=rtl] & {
     background-image: $cassiopeia-header-grad-rtl;
-
-    .back-top {
-      margin-right: auto;
-      margin-left: 0;
-    }
   }
 }

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -9,6 +9,10 @@
   }
 }
 
+body {
+  position: relative;
+}
+
 img {
   max-width: 100%;
 }

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -22,6 +22,7 @@
 // Blocks
 @import "blocks/global"; // Leave this first
 @import "blocks/alerts";
+@import "blocks/back-to-top";
 @import "blocks/banner";
 @import "blocks/footer";
 @import "blocks/form";


### PR DESCRIPTION
Tried to create a PR on @N6REJ https://github.com/joomla/cassiopeia/pull/168
It failed..sorry.. 
Therefor I have created this new PR less changes, less css

- There is only one choice in Cassiopeia Template style = use back-to-top or not use back-to-top
- When using back-to-top... it will appear 5rem outside the viewport and it will stick bottom right on the screen until you hit bottom.

- `npm run build:css` (just like @N6REJ no JS, only css)