### PR TITLE
Use --cassiopeia-color-link for links

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -28,7 +28,7 @@ h6 {
 }
 
 a {
-  color: var(--cassiopeia-color-primary);
+  color: var(--cassiopeia-color-link);
 
   &:not([class]) {
     text-decoration: underline;

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -12,7 +12,7 @@ $cassiopeia-inverted-text-color:      var(--cassiopeia-color-hover);
 
 // Standard
 $standard-color-primary:              hsl(220, 67%, 20%);
-$standard-color-link:                 hsl(220, 67%, 20%);
+$standard-color-link:                 hsl(220, 67%, 40%);
 $standard-color-hover:                hsl(242, 30%, 36%);
 
 // Alternative


### PR DESCRIPTION
Pull Request for Issue #171 .

### Summary of Changes
Change color: var(--cassiopeia-color-primary); to color: var(--cassiopeia-color-link);
Colour for links is now hsl(220, 67%, 40%); to match to color-primary: hsl(220, 67%, 20%);

### Testing Instructions
Run npm


### Expected result
Links are bright blue
![grafik](https://user-images.githubusercontent.com/9153168/95887598-55b78e80-0d80-11eb-819c-80e83880ff51.png)



### Actual result
Links are dark blue and difficult to see

