### PR TITLE
[Metismenu] Fix appending anchor css for heading and separator

### DIFF
--- a/templates/cassiopeia/html/mod_menu/metismenu_heading.php
+++ b/templates/cassiopeia/html/mod_menu/metismenu_heading.php
@@ -15,7 +15,7 @@ use Joomla\Utilities\ArrayHelper;
 $attributes          = [];
 $attributes['title'] = $item->anchor_title ? $item->anchor_title : null;
 $attributes['class'] = 'mod-menu__heading nav-header';
-$attributes['class'] .= $item->anchor_css ? $item->anchor_css : null;
+$attributes['class'] .= $item->anchor_css ? ' ' . $item->anchor_css : null;
 
 if ($item->deeper)
 {

--- a/templates/cassiopeia/html/mod_menu/metismenu_separator.php
+++ b/templates/cassiopeia/html/mod_menu/metismenu_separator.php
@@ -15,7 +15,7 @@ use Joomla\Utilities\ArrayHelper;
 $attributes          = [];
 $attributes['title'] = $item->anchor_title ? $item->anchor_title : null;
 $attributes['class'] = 'mod-menu__separator separator';
-$attributes['class'] .= $item->anchor_css ? $item->anchor_css : null;
+$attributes['class'] .= $item->anchor_css ? ' ' . $item->anchor_css : null;
 
 if ($item->deeper)
 {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Have a space between the previously added css class and the anchor css if the latter is appended.

### Testing Instructions

Code review should be sufficient. Check also operator precedence.

### Expected result

Correct css classes when anchor css is used.

### Actual result

Missing space between `nav-header` and any appended anchor css in the class attribute.

### Documentation Changes Required

None.