### PR TITLE
Remove double underline in menu

### DIFF
--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -17,6 +17,7 @@
 
   nav {
     padding: 0;
+    margin-top: $cassiopeia-grid-gutter / 2;
   }
 
   .site-description {
@@ -129,11 +130,10 @@
         background: $white;
       }
 
-      @include media-breakpoint-down(md) {
+      @include media-breakpoint-down(sm) {
         &.active > a,
         &.active > span,
-        > a:hover,
-        > span:hover {
+        > a:hover {
           text-decoration: underline;
         }
       }
@@ -155,6 +155,10 @@
     .fas {
       font-size: 24px;
     }
+  }
+
+  .container-search {
+    margin-top: $cassiopeia-grid-gutter / 2;
   }
 
   .mod-finder {

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -27,7 +27,6 @@
             text-decoration: underline;
           }
 
-          span:hover,
           a:hover {
             text-decoration: underline;
           }


### PR DESCRIPTION
Pull Request for Issue #162.

### Summary of Changes
Remove double underline in menu (top position)
Remove underline for span items in menu
Add margin to nav and search


### Testing Instructions
Run npm
Test with a metismenu on menu position and change the display size until the menu switch to hamburger. Look at different sizes the hover on menu items


### Expected result
No double underline on menu items
Search is not too close to the menu in display size around 770px when the search flip under the menu
![grafik](https://user-images.githubusercontent.com/9153168/96770078-4ec3f800-13e0-11eb-90e9-5d8aa157dd15.png)


### Actual result
Double underline in display size around 770px
Search is too close to the menu


