### PR TITLE
Feature cassiopeia/remove obsolete margin

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -264,6 +264,7 @@
 // Modules
 
 .breadcrumb {
+  margin-bottom: 0;
   background-color: hsla(0, 0%, 0%, .03);
 }
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -4,6 +4,7 @@
 // The following is a restyle for the system alerts
 #system-message-container {
   &:empty {
+    display: none;
     margin-top: 0;
   }
 }

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -2,6 +2,11 @@
 @import "../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
 
 // The following is a restyle for the system alerts
+#system-message-container {
+  &:empty {
+    margin-top: 0;
+  }
+}
 
 #system-message-container joomla-alert {
   position: relative;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/31195

### Summary of Changes

After merge of https://github.com/joomla/joomla-cms/pull/31195 this PR will fix obsolete spacing between elements.
It removes the margin-bottom from both .breadcrumb and empty alert box. And it removes the empty alert box from the DOM.

### Testing Instructions

- wait until https://github.com/joomla/joomla-cms/pull/31195 is merged
- Joomla 4 test and press login button on right sidebar
- It will take you to index.php/author-login with an alert message
- Close the alert message by pressing the `x`
- Notice the gap between the breadcrumbs and the output of the component. 
- Apply patch, run `npm run build:css` and repeat the steps above

### Expected result

The expected result is a gap of 1rem. Breadcrumb and the output of the component have no obsolete margin between the elements. 

<img width="1326" alt="Schermafbeelding 2020-10-22 om 08 56 22" src="https://user-images.githubusercontent.com/639822/96836668-992b9000-1445-11eb-8207-81b450119666.png">


### Actual result

The actual result is a gap bigger than 1rem. This is due to a margin-bottom on the breadcrumbs and a margin-top added to the empty alert box, although it is empty. It is a succeeding element and therefor it gets a margin-top.

<img width="1328" alt="Schermafbeelding 2020-10-22 om 08 57 14" src="https://user-images.githubusercontent.com/639822/96836682-9f217100-1445-11eb-93f2-5118d86e9a21.png">


### Documentation Changes Required

