### PR TITLE
Add class to the <a> element for logo / site title to avoid underline

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -112,7 +112,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 	<header class="header container-header full-width <?php echo $stickyHeader; ?>">
 		<div class="grid-child">
 			<div class="navbar-brand">
-				<a href="<?php echo $this->baseurl; ?>/">
+				<a class="brand-logo" href="<?php echo $this->baseurl; ?>/">
 					<?php echo $logo; ?>
 				</a>
 				<?php if ($this->params->get('siteDescription')) : ?>


### PR DESCRIPTION
Pull Request for Issue #181 .

### Summary of Changes
Add class to the <a> element for logo / site title to avoid underline


### Testing Instructions
See issue #181 
Don't need npm


### Expected result
No underline in template title


### Actual result
See issue

