### PR TITLE
Add padding right and left on submenus (metismenu)

### DIFF
--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -67,12 +67,9 @@
           > ul {
             position: relative;
             top: 0;
-            padding: 0 0 0 1em;
+            padding: 0 1em;
             background-color: rgba(0,0,0,.03);
             box-shadow: none;
-          }
-          [dir="rtl"] & > ul {
-            padding: 0 1em 0 0;
           }
         }
       }
@@ -128,11 +125,8 @@
         > ul {
           position: relative;
           top: 0;
-          padding: 0 0 0 1em;
+          padding: 0 1em;
           box-shadow: none;
-        }
-        [dir="rtl"] & > ul {
-          padding: 0 1em 0 0;
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue #196 .

### Summary of Changes
Add padding right and left on submenus (metismenu) 


### Testing Instructions
npm run build:css
See issue


### Expected result
The submenu has padding right and left


### Actual result
No padding right (or left in rtl)

