### PR TITLE
[Blog Sample Data] Use end level "All" for the metismenu example module "Main Menu Blog"

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -1187,7 +1187,7 @@ class PlgSampledataBlog extends CMSPlugin
 					'menutype'        => $menuTypes[0],
 					'layout'          => 'cassiopeia:metismenu',
 					'startLevel'      => 1,
-					'endLevel'        => 3,
+					'endLevel'        => 0,
 					'showAllChildren' => 1,
 					'class_sfx'       => '',
 					'cache'           => 1,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When someone decides to extend the metismenu example ("Main Menu Blog" coming with blog sample data) by more submenu items so that it becomes deeper than 3 levels, he or she will not see the menu items for these levels because the menu module is installed with end level 3 in the advanced options.

This is very confusing, as you can see in issue #190 .

Even if it's bad UX and also not really accessible having a too deep menu structure, we should not enforce that by using the end level limitation.

Therefore this PR changes the end level to "All" for the metismenu example.

### Testing Instructions

If you have development environment for Joomla 4, checkout the [development-fix-main-menu-blog-submenu-options](https://github.com/joomla/cassiopeia/tree/development-fix-main-menu-blog-submenu-options) branch, pull the latest changes, run "composer install" and "npm ci", and then make a new installation.

If you don't have that, use the following package to make a new installation [https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_2020-10-24_v2.zip](https://test5.richard-fath.de/Joomla_4.0.0-beta5-dev-Cassiopeia-Test-Full_Package_2020-10-24_v2.zip), and then apply the changes of this PR here "manually" before doing the next step.

After that, login to backend and install "Blog Sample Data".

Now edit module "Main Menu Blog" and check the advanced options.

### Actual result BEFORE applying this Pull Request

![2020-10-24_01](https://user-images.githubusercontent.com/7413183/97083066-1c97dd80-160e-11eb-9c04-4a1346521ff4.png)

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/1296369/97001964-2e578300-1531-11eb-9602-873194810ae6.png)

### Documentation Changes Required

None.