### PR TITLE
[Metismenu] Auto-collapse metismenu when click outside of menu

### DIFF
--- a/templates/cassiopeia/js/mod_menu/menu-metismenu.js
+++ b/templates/cassiopeia/js/mod_menu/menu-metismenu.js
@@ -3,8 +3,15 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
 	allMenus.forEach(menu => {
 		// eslint-disable-next-line no-new, no-undef
-		new MetisMenu(menu, {
+		const mm = new MetisMenu(menu, {
 			triggerElement: 'button.mm-toggler'
+		}).on("shown.metisMenu", function(event) {
+			window.addEventListener("click", function mmClick(e) {
+				if (!event.target.contains(e.target)) {
+					mm.hide(event.detail.shownElement);
+					window.removeEventListener("click", mmClick);
+				}
+			});
 		});
 	});
 });

--- a/templates/cassiopeia/js/mod_menu/menu-metismenu.js
+++ b/templates/cassiopeia/js/mod_menu/menu-metismenu.js
@@ -1,17 +1,17 @@
-document.addEventListener("DOMContentLoaded", function(event) {
-	const allMenus = document.querySelectorAll('ul.mod-menu_metismenu');
+document.addEventListener('DOMContentLoaded', () => {
+  const allMenus = document.querySelectorAll('ul.mod-menu_metismenu');
 
-	allMenus.forEach(menu => {
-		// eslint-disable-next-line no-new, no-undef
-		const mm = new MetisMenu(menu, {
-			triggerElement: 'button.mm-toggler'
-		}).on("shown.metisMenu", function(event) {
-			window.addEventListener("click", function mmClick(e) {
-				if (!event.target.contains(e.target)) {
-					mm.hide(event.detail.shownElement);
-					window.removeEventListener("click", mmClick);
-				}
-			});
-		});
-	});
+  allMenus.forEach((menu) => {
+    // eslint-disable-next-line no-new, no-undef
+    const mm = new MetisMenu(menu, {
+      triggerElement: 'button.mm-toggler',
+    }).on('shown.metisMenu', (event) => {
+      window.addEventListener('click', function mmClick(e) {
+        if (!event.target.contains(e.target)) {
+          mm.hide(event.detail.shownElement);
+          window.removeEventListener('click', mmClick);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
Pull Request for Issue #191 part 1 .

### Summary of Changes

Add auto-collapse of any expanded metismenu when clicking outside the menu.

**Note:** The expanded/collapsed state of parent menu items which are in a submenu will not be changed, i.e. it you expand the top level item's drop down again, further sub-menu on the levels below that item are expanded already when they were expanded at the last time when the top-level submenu was expanded.

### Testing Instructions

Make a new installation using the branch of this PR, or if you don't have a development environment to run composer and npm, make a new installation with the installation package linked in PR #48 and then apply the changes made by this PR or simply replace the modified javascript file by the file from this PR.

No need to run npm then, the js file is loaded as it is and not compiled into anything.

After installation, go to backend and install **blog** sample data.

Then create some more metismenus for frontend e.g. by duplicating the module "Main Menu Blog" do different module positions.

Now use the metismenus in frontend. Expand one, click outside the menu, expand again one, expand the other one, try to find out if the 2 or more metismenu have any impact on each other.

### Expected result

When clicking outside of a metismenu with an expanded pull-down menu, the pull-down menu collapses.

When expanding a pull down of a metismenu and then expanding a pull-down of another metismenu, the pull down of the first menu is collapsed.

### Actual result

When clicking outside of a metismenu with an expanded pull-down menu, the pull-down menu remains expanded.

When expanding a pull down of a metismenu and then expanding a pull-down of another metismenu, the pull down of the first menu remains expanded.

### Documentation Changes Required

None.