### PR TITLE
Update offline.scss

### DIFF
--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   padding: 20px;
   overflow: hidden;
 }


### PR DESCRIPTION
Pull Request for Issue #219 .

### Summary of Changes
Change height to min-height to allow scroll if an offline image makes the form bigger


### Testing Instructions
Run npm run build:css
Put the site offline and select a big (in height) offline image

### Expected result
You can scroll on the page

### Actual result
You can't scroll (see issue)

