### PR TITLE
Remove overflow hidden for cards

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -192,7 +192,3 @@ meter {
   border-bottom-right-radius: .25rem;
   border-bottom-left-radius: 0;
 }
-
-.card {
-  overflow: hidden;
-}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Overflow hidden makes problems if a module contains overlapping dropdowns. 

### Testing Instructions
npm needed. 


### NoteExpected result
This causes another issue: Vertical metismenu with long menu item names will overlap now, as it has no word wrap. 


