### PR TITLE
Fix SCSS code style order of properties

### DIFF
--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -21,10 +21,10 @@ $scrollLength: 100vh;
 .back-to-top-link {
   position: fixed;
   position: sticky;
-  pointer-events: all;
   top: calc(#{$scrollLength} - #{$cassiopeia-grid-gutter * 3});
   padding: $cassiopeia-grid-gutter/2;
   color: var(--cassiopeia-color-primary, $standard-color-primary);
+  pointer-events: all;
   background-color: var(--white, $white);
   border: 1px solid transparent;
   border-radius: $border-radius;

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -104,8 +104,8 @@ small,
 }
 
 dd {
-  margin-bottom: 0;
   padding: 0 0 0 ($cassiopeia-grid-gutter*2);
+  margin-bottom: 0;
 }
 
 [dir="rtl"] dd {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -51,8 +51,8 @@
 .container-sidebar-left,
 .container-sidebar-right {
   display: flex;
-  flex-direction: column;
   flex: 1;
+  flex-direction: column;
 
   > * {
     margin-bottom: 0;

--- a/templates/cassiopeia/scss/tools/mixins/_visually-hidden.scss
+++ b/templates/cassiopeia/scss/tools/mixins/_visually-hidden.scss
@@ -21,10 +21,10 @@
 //
 @mixin a11y-visually-hidden {
   position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  overflow: hidden;
-  height: 1px;
   width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
   word-wrap: normal;
 }
 
@@ -36,10 +36,10 @@
   &:active,
   &:focus {
     position: static !important;
-    clip: auto;
-    overflow: visible;
-    height: auto;
     width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue #105 (part).

### Summary of Changes

Fixes all SCSS code style errors found by the stylelint tool in the Cassiopeia template's SCSS files, except of one `Unexpected duplicate "position"` error found here:

https://github.com/joomla/cassiopeia/blob/development/templates/cassiopeia/scss/blocks/_back-to-top.scss#L22-L23

Is seems this one can't be avoided.

### Testing Instructions

Checkout the branch of this PR, then run `composer install` and `npm ci`, then run
`node ./node_modules/stylelint/bin/stylelint.js --config build/.stylelintrc.json -s scss "templates/**/*.scss"`
in the Joomla root folder.

### Actual result BEFORE applying this Pull Request

```
templates/cassiopeia/scss/blocks/_back-to-top.scss
 23:3  >  Unexpected duplicate "position"                  declaration-block-no-duplicate-properties
 25:3  >  Expected "top" to come before "pointer-events"   order/properties-order                   

templates/cassiopeia/scss/blocks/_global.scss
 108:3  >  Expected "padding" to come before "margin-bottom"   order/properties-order

templates/cassiopeia/scss/blocks/_layout.scss
 55:3  >  Expected "flex" to come before "flex-direction"   order/properties-order

templates/cassiopeia/scss/tools/mixins/_visually-hidden.scss
 25:3  >  Expected "overflow" to come before "clip"     order/properties-order
 26:3  >  Expected "height" to come before "overflow"   order/properties-order
 27:3  >  Expected "width" to come before "height"      order/properties-order
 40:5  >  Expected "overflow" to come before "clip"     order/properties-order
 41:5  >  Expected "height" to come before "overflow"   order/properties-order
 42:5  >  Expected "width" to come before "height"      order/properties-order
```

### Expected result AFTER applying this Pull Request

```
templates/cassiopeia/scss/blocks/_back-to-top.scss
 23:3  > Unexpected duplicate "position"   declaration-block-no-duplicate-properties
```

### Documentation Changes Required

None.