### PR TITLE
Change colour value for $cyan (info)

### DIFF
--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -53,7 +53,7 @@ $orange:                              hsl(27, 98%, 54%);
 $yellow:                              hsl(35, 84%, 62%);
 $green:                               hsl(120, 32%, 39%);
 $teal:                                hsl(194, 66%, 61%);
-$cyan:                                hsl(188, 80%, 32%);
+$cyan:                                hsl(207, 49%, 37%);
 
 $colors: (
   blue: $blue,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Change hsl values for colour variable $cyan to make it more harmonic with the template colours 


### Testing Instructions
Run npm run build:css 

### Expected result
![image](https://user-images.githubusercontent.com/9153168/99145508-d7485800-266f-11eb-80da-6abeabd64668.png)

The info button is more blue


### Actual result
![image](https://user-images.githubusercontent.com/9153168/99145504-d0b9e080-266f-11eb-9cb9-ec07967df9df.png)


