### PR TITLE
Fix SCSS linter error unexpected named color "white"

### DIFF
--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -33,7 +33,7 @@
           height: 4px;
           margin: 1rem auto 2rem;
           content: "";
-          background: white;
+          background: $white;
         }
         .lead {
           font-size: 150vh;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes error `Unexpected named color "white"` reported by the SCSS linter for the `templates/cassiopeia/scss/blocks/_banner.scss` file.

The error was introduced with PR #227 .

### Testing Instructions

Code review and test if the separator line in the banner is still white.

Run `node ./node_modules/stylelint/bin/stylelint.js --config build/.stylelintrc.json -s scss "templates/**/*.scss"`.

### Actual result BEFORE applying this Pull Request

The separator line in the banner is white.

The linter report an `Unexpected named color "white"` error for file `templates/cassiopeia/scss/blocks/_banner.scss`.

### Expected result AFTER applying this Pull Request

The separator line in the banner is still white.

The linter doesn't report the `Unexpected named color "white"` error for file `templates/cassiopeia/scss/blocks/_banner.scss`.

### Documentation Changes Required

None.