### PR TITLE
Fix SCSS style linter reporting unexpected duplicate "position" for _back-to-top.scss

### DIFF
--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -20,6 +20,7 @@ $scrollLength: 100vh;
 
 .back-to-top-link {
   position: fixed;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
   position: sticky;
   top: calc(#{$scrollLength} - #{$cassiopeia-grid-gutter * 3});
   padding: $cassiopeia-grid-gutter/2;


### PR DESCRIPTION
Pull Request for remaining issue mentioned in #235 .

### Summary of Changes

Fixes the remaining SCSS code style errors found by the stylelint tool in the Cassiopeia template's SCSS files here:

https://github.com/joomla/cassiopeia/blob/development/templates/cassiopeia/scss/blocks/_back-to-top.scss#L22-L23

The duplicate property can't be avoided, as far as @drmenzelit told me.

So this PR adds a comment for the style linter to ignore that one line.

See [https://stylelint.io/user-guide/ignore-code](https://stylelint.io/user-guide/ignore-code) for how to do that.

### Testing Instructions

Checkout the branch of this PR, then run `composer install` and `npm ci`, then run
`node ./node_modules/stylelint/bin/stylelint.js --config build/.stylelintrc.json -s scss "templates/**/*.scss"`
in the Joomla root folder.

### Actual result BEFORE applying this Pull Request

```
templates/cassiopeia/scss/blocks/_back-to-top.scss
 23:3  > Unexpected duplicate "position"   declaration-block-no-duplicate-properties
```

### Expected result AFTER applying this Pull Request

No errors reported by the style linter.

### Documentation Changes Required

None.