### PR TITLE
#242 revert removal of `id="back-top"` to prevent `#top` in the url after clicking back-top

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -205,7 +205,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 
 	<?php if ($this->params->get('backTop') == 1) : ?>
 		<div class="back-to-top-wrapper">
-			<a href="#top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
+			<a href="#top" id="back-top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
 				<span class="icon-arrow-up icon-fw" aria-hidden="true"></span>
 			</a>
 		</div>


### PR DESCRIPTION
Pull Request for Issue #242 .

### Summary of Changes

this PR will revert the removal of `id="back-top"` in the link which leads back to top. 
Adding the id will trigger javascript to preventDefault

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

