### PR TITLE
improve colour of tags (a11y)

### DIFF
--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -86,15 +86,15 @@
   }
 }
 .choices__list--multiple .choices__item {
-  border-radius: 5px;
   font-size: inherit;
   font-weight: 500;
-  background-color: var(--info);
-  border: 1px solid $white;;
   color: $white;
+  background-color: var(--info);
+  border: 1px solid $white;
+  border-radius: $border-radius;
 
   &.is-highlighted {
-    color: white;
+    color: $white;
     background-color: var(--info);
     border-color: var(--info);
     opacity: .8;
@@ -113,7 +113,7 @@
     margin-bottom: 0;
     margin-left: 8px;
     line-height: 1;
-    border-left: 1px solid #ffffff;
+    border-left: 1px solid $white;
     opacity: .75;
 
     &:hover,

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -95,8 +95,8 @@
 
   &.is-highlighted {
     color: white;
-    background-color: #264f70;
-    border-color: #234867;
+    background-color: var(--info);
+    border-color: var(--info);
     opacity: .8;
   }
 }

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -85,6 +85,21 @@
     }
   }
 }
+.choices__list--multiple .choices__item {
+  border-radius: 5px;
+  font-size: inherit;
+  font-weight: 500;
+  background-color: var(--info);
+  border: 1px solid $white;;
+  color: $white;
+
+  &.is-highlighted {
+    color: white;
+    background-color: #264f70;
+    border-color: #234867;
+    opacity: .8;
+  }
+}
 
 .choices[data-type*="select-multiple"],
 .choices[data-type*="text"] {
@@ -98,7 +113,7 @@
     margin-bottom: 0;
     margin-left: 8px;
     line-height: 1;
-    border-left: 1px solid hsl(187, 100%, 32%);
+    border-left: 1px solid #ffffff;
     opacity: .75;
 
     &:hover,


### PR DESCRIPTION
Resolve patially Issue https://issues.joomla.org/tracker/joomla-cms/29137 .

### Summary of Changes
Tags in the edit form have a colour with weak clolour contrast. 
This PR adds the colour of btn-inform. 


### Testing Instructions
Needs npm 
Open an article for editing, add a tag. 


### Expected result
![grafik](https://user-images.githubusercontent.com/1035262/99407382-50091780-28ef-11eb-9b73-b2883b33991e.png)



### Actual result
see  https://issues.joomla.org/tracker/joomla-cms/29137 .


### Documentation Changes Required
no
