### PR TITLE
Improvement on font-family and font-size for editor.css

### DIFF
--- a/templates/system/css/editor.css
+++ b/templates/system/css/editor.css
@@ -5,47 +5,36 @@
 
 body {
 	background: #fff;
-	font-family: Tahoma, Helvetica, Arial, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 	line-height: 1.3em;
-	font-size: 12px;
-	color: #333;
+	font-size: 1rem;
+	color: #22262a;
+}
+
+h1, h2, h3, h4 {
+	font-weight: bold;
 }
 
 h1 {
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 16px;
-	font-weight: bold;
-	color: #666;
+	font-size: 1.857rem;
 }
 
 h2 {
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 14px;
-	font-weight: normal;
-	color: #333;
+	font-size: 1.571rem;
 }
 
 h3 {
-  font-weight: bold;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 13px;
-  color: #135cae;
-}
-
-h4 {
-	font-weight: bold;
-	font-family: Arial, Helvetica, sans-serif;
-	color: #333;
+  font-size: 1.286rem;
 }
 
 a:link, a:visited {
-	color: #1B57B1; 
+	color: #1B57B1;
 	text-decoration: none;
 	font-weight: normal;
 }
 
 a:hover {
-	color: #00c;	
+	color: #00c;
 	text-decoration: underline;
 	font-weight: normal;
 }


### PR DESCRIPTION
Pull Request for Issue #233 .

### Summary of Changes
Change font-family and font-size in templates/system/editor.css
font-family is like in Bootstrap a long list of system fonts
font-size is now in rem not in px

### Testing Instructions
Edit an article in frontend or backend, you should see the difference in font size


### Expected result
Font is bigger as before


