### PR TITLE
Add backgroud to html for the accessibility plugin

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -9,6 +9,10 @@
   }
 }
 
+html {
+  background-color: $white;
+}
+
 body {
   position: relative;
 }


### PR DESCRIPTION
Pull Request for Issue #66 .

### Summary of Changes
Added a background color to html. This enables the accessibility plugin to invert the backend colour.


### Testing Instructions
Apply the patch, (npm run build:css) then first make sure that all colours are as usual.
Then activate the accessibility plugin for the frontend and activate inverse colour


### Expected result
All colours are inverted 


### Actual result
Colours are only inverted sidebars but hot for the whole site


### Documentation Changes Required

