### PR TITLE
Cassiopeia/tags x and font size

### DIFF
--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -19,6 +19,10 @@
   line-height: 1;
 }
 
+.choices__item {
+  position: relative;
+}
+
 // Fix close button
 .choices__button_joomla {
   position: relative;
@@ -48,21 +52,16 @@
 .choices[data-type*="select-one"] {
   .choices__button_joomla {
     position: absolute;
-    top: 50%;
     right: 0;
-    width: 20px;
-    height: 20px;
+    width: 1.25em;
+    height: 1.25em;
     padding: 0;
-    margin-top: -10px;
-    margin-right: 45px;
     border-radius: 10em;
     opacity: .5;
 
     [dir=rtl] & {
       right: auto;
       left: 0;
-      margin-right: 0;
-      margin-left: 45px;
     }
 
     &:hover,
@@ -80,30 +79,35 @@
   }
 
   .choices__inner {
-    padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
-    background: url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
-    background-color: $custom-select-bg;
+    padding: $custom-select-padding-y $custom-select-indicator-padding $custom-select-padding-y $custom-select-padding-x;
+    background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
 
     [dir=rtl] & {
-      padding: $custom-select-padding-y $custom-select-padding-x $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding);
-      background: url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
-      background-color: $custom-select-bg;
+      padding: $custom-select-padding-y $custom-select-padding-x $custom-select-padding-y $custom-select-indicator-padding;
+      background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
     }
   }
 }
-.choices__list--multiple .choices__item {
-  font-size: inherit;
-  font-weight: 500;
-  color: $white;
-  background-color: var(--info);
-  border: 1px solid $white;
-  border-radius: $border-radius;
 
-  &.is-highlighted {
+.choices__list--single {
+  padding-right: .25em;
+}
+
+.choices__list--multiple {
+  .choices__item {
+    font-size: inherit;
+    font-weight: 500;
     color: $white;
     background-color: var(--info);
-    border-color: var(--info);
-    opacity: .8;
+    border: 1px solid $white;
+    border-radius: $border-radius;
+
+    &.is-highlighted {
+      color: $white;
+      background-color: var(--info);
+      border-color: var(--info);
+      opacity: .8;
+    }
   }
 }
 
@@ -112,12 +116,12 @@
   .choices__button_joomla {
     position: relative;
     display: inline-block;
-    width: 8px;
-    padding-left: 16px;
+    width: .5em;
+    padding-left: 1em;
     margin-top: 0;
-    margin-right: -4px;
+    margin-right: -.25em;
     margin-bottom: 0;
-    margin-left: 8px;
+    margin-left: .5em;
     line-height: 1;
     border-left: 1px solid $white;
     opacity: .75;

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -8,22 +8,6 @@
 // Cassiopea Variables, Functions and Mixins
 @import "../../tools/tools";
 
-// Fix position
-.choices__list--dropdown {
-  z-index: 10;
-}
-
-.choices__inner,
-.choices__input {
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.choices__item {
-  position: relative;
-}
-
-// Fix close button
 .choices__button_joomla {
   position: relative;
   text-indent: -9999px;
@@ -31,6 +15,7 @@
   background: none;
   border: 0;
   appearance: none;
+  opacity: .75;
 
   &::before {
     position: absolute;
@@ -38,8 +23,11 @@
     right: 0;
     bottom: 0;
     left: 0;
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     text-align: center;
+    line-height: 1.5;
     text-indent: 0;
     content: "\00d7";
   }
@@ -47,55 +35,101 @@
   &:focus {
     outline: none;
   }
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
 }
 
-.choices[data-type*="select-one"] {
-  .choices__button_joomla {
-    position: absolute;
-    right: 0;
-    width: 1.25em;
-    height: 1.25em;
-    padding: 0;
-    border-radius: 10em;
-    opacity: .5;
-
-    [dir=rtl] & {
-      right: auto;
-      left: 0;
-    }
-
-    &:hover,
-    &:focus {
-      opacity: 1;
-    }
-
-    &:focus {
-      box-shadow: 0 0 0 2px hsl(187, 100%, 42%);
-    }
-  }
-
-  &::after {
-    display: none;
-  }
+.choices {
+  font-size: 1rem;
+  line-height: 1.5;
 
   .choices__inner {
-    padding: $custom-select-padding-y $custom-select-indicator-padding $custom-select-padding-y $custom-select-padding-x;
-    background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
+    min-height: calc(1.5em + 1.2rem + 2px);
+  }
 
-    [dir=rtl] & {
-      padding: $custom-select-padding-y $custom-select-padding-x $custom-select-padding-y $custom-select-indicator-padding;
-      background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
+  &[data-type*="select-one"] {
+    .choices__inner {
+      padding: $input-btn-padding-y $custom-select-indicator-padding $input-btn-padding-y $input-btn-padding-x;
+      background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
+
+      [dir=rtl] & {
+        padding: $input-btn-padding-y $input-btn-padding-x $input-btn-padding-y $custom-select-indicator-padding;
+        background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
+      }
+    }
+
+    .choices__button_joomla {
+      position: absolute;
+      right: 0;
+      width: 1.25em;
+      height: 1.25em;
+      padding: 0;
+      border-radius: 10em;
+      opacity: .5;
+
+      [dir=rtl] & {
+        right: auto;
+        left: 0;
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 2px hsl(187, 100%, 42%);
+      }
+    }
+
+    &::after {
+      display: none;
     }
   }
+
+  &[data-type*="select-multiple"],
+  &[data-type*="text"] {
+    .choices__inner {
+      padding: .375 * $input-btn-padding-y .25 * $input-btn-padding-x .125 * $input-btn-padding-y;
+    }
+
+    .choices__button_joomla {
+      position: relative;
+      display: inline-block;
+      width: .5em;
+      padding-left: 1em;
+      margin-top: 0;
+      margin-right: -.25em;
+      margin-bottom: 0;
+      margin-left: .5em;
+      line-height: 1;
+      border-left: 1px solid $white;
+
+      &::before {
+        color: $white;
+      }
+    }
+  }
+}
+
+.choices__inner,
+.choices__input {
+  font-size: 1em;
+  line-height: 1.5;
+}
+
+.choices__item {
+  position: relative;
 }
 
 .choices__list--single {
-  padding-right: .25em;
+  padding: 0;
 }
 
 .choices__list--multiple {
   .choices__item {
     display: inline-flex;
+    padding: .5 * $input-btn-padding-y .5 * $input-btn-padding-x;
+    margin-right: .25 * $input-btn-padding-x;
+    margin-bottom: .125 * $input-btn-padding-y;
     font-size: inherit;
     font-weight: 500;
     color: $white;
@@ -112,30 +146,8 @@
   }
 }
 
-.choices[data-type*="select-multiple"],
-.choices[data-type*="text"] {
-  .choices__button_joomla {
-    position: relative;
-    display: inline-block;
-    width: .5em;
-    padding-left: 1em;
-    margin-top: 0;
-    margin-right: -.25em;
-    margin-bottom: 0;
-    margin-left: .5em;
-    line-height: 1;
-    border-left: 1px solid $white;
-    opacity: .75;
-
-    &:hover,
-    &:focus {
-      opacity: 1;
-    }
-
-    &::before {
-      color: $white;
-    }
-  }
+.choices__list--dropdown {
+  z-index: 10;
 }
 
 .choices__heading {

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -99,8 +99,9 @@
       position: relative;
       display: inline-block;
       width: .5em;
-      padding-left: 1em;
-      margin: 0 -1 * .25em 0 .5em;
+      padding-right: $input-btn-padding-y;
+      padding-left: $input-btn-padding-y;
+      margin: 0 -.25em 0 .5em;
       line-height: 1;
       border-left: 1px solid $white;
 
@@ -109,9 +110,9 @@
       }
 
       [dir=rtl] & {
-        padding-right: 1em;
-        padding-left: 0;
-        margin: 0 .5em 0 -1 * .25em;
+        padding-right: $input-btn-padding-y;
+        padding-left: $input-btn-padding-y;
+        margin: 0 .5em 0 -.25em;
         border-right: 1px solid $white;
         border-left: 0;
       }
@@ -164,6 +165,11 @@
       background-color: var(--info);
       border-color: var(--info);
       opacity: .8;
+    }
+
+    [dir=rtl] & {
+      margin-right: 0;
+      margin-left: .25 * $input-btn-padding-x;
     }
   }
 }

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -95,6 +95,7 @@
 
 .choices__list--multiple {
   .choices__item {
+    display: inline-flex;
     font-size: inherit;
     font-weight: 500;
     color: $white;

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -150,6 +150,15 @@
     border: 1px solid $white;
     border-radius: $border-radius;
 
+    &[data-deletable] {
+      padding-right: .375rem;
+
+      [dir=rtl] & {
+        padding-right: .5 * $input-btn-padding-x;
+        padding-left: .375rem;
+      }
+    }
+
     &.is-highlighted {
       color: $white;
       background-color: var(--info);

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -24,10 +24,10 @@
     bottom: 0;
     left: 0;
     display: flex;
-    justify-content: center;
     align-items: center;
-    text-align: center;
+    justify-content: center;
     line-height: 1.5;
+    text-align: center;
     text-indent: 0;
     content: "\00d7";
   }

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -89,6 +89,10 @@
   &[data-type*="text"] {
     .choices__inner {
       padding: .375 * $input-btn-padding-y .25 * $input-btn-padding-x .125 * $input-btn-padding-y;
+
+      [dir=rtl] & {
+        text-align: right;
+      }
     }
 
     .choices__button_joomla {
@@ -96,15 +100,20 @@
       display: inline-block;
       width: .5em;
       padding-left: 1em;
-      margin-top: 0;
-      margin-right: -.25em;
-      margin-bottom: 0;
-      margin-left: .5em;
+      margin: 0 -1 * .25em 0 .5em;
       line-height: 1;
       border-left: 1px solid $white;
 
       &::before {
         color: $white;
+      }
+
+      [dir=rtl] & {
+        padding-right: 1em;
+        padding-left: 0;
+        margin: 0 .5em 0 -1 * .25em;
+        border-right: 1px solid $white;
+        border-left: 0;
       }
     }
   }
@@ -122,6 +131,10 @@
 
 .choices__list--single {
   padding: 0;
+
+  [dir=rtl] & {
+    text-align: right;
+  }
 }
 
 .choices__list--multiple {

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -13,6 +13,12 @@
   z-index: 10;
 }
 
+.choices__inner,
+.choices__input {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 // Fix close button
 .choices__button_joomla {
   position: relative;


### PR DESCRIPTION
### Summary of Changes

This PR will convert the px values of choices css into relative sizes.
This PR will also increase font size selected tags. 
This PR will also fix the position of the `x` in the multi select

### Testing Instructions

- Login frontend
- Edit an article
- Go to tab "Publishing"
- Notice the position of the `x` at categories and notice the styling of present tags (add if none are present)
- Apply patch
- run `npm run build:css`
- Refresh page you are editing. 

### Expected result

<img width="961" alt="Schermafbeelding 2020-11-22 om 13 41 36" src="https://user-images.githubusercontent.com/639822/99903997-7bfa1380-2cc8-11eb-94f1-f50f82061132.png">


### Actual result

<img width="959" alt="Schermafbeelding 2020-11-22 om 13 42 26" src="https://user-images.githubusercontent.com/639822/99904009-93d19780-2cc8-11eb-9e17-46477f68a3ae.png">


### Documentation Changes Required

