### PR TITLE
Show only article heading, no page heading

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -1226,9 +1226,9 @@ class PlgSampledataBlog extends CMSPlugin
 				'parent_id'    => $menuIdsLevel1[1],
 				'component_id' => ExtensionHelper::getExtensionRecord('com_content', 'component')->extension_id,
 				'params'       => array(
-					'menu_show' => 1,
-					'show_page_heading' => 1,
-					'secure'    => 0,
+					'menu_show'         => 1,
+					'show_page_heading' => 0,
+					'secure'            => 0,
 				),
 			),
 			array(
@@ -1238,9 +1238,9 @@ class PlgSampledataBlog extends CMSPlugin
 				'parent_id'    => $menuIdsLevel1[1],
 				'component_id' => ExtensionHelper::getExtensionRecord('com_content', 'component')->extension_id,
 				'params'       => array(
-					'menu_show' => 1,
-					'show_page_heading' => 1,
-					'secure'    => 0,
+					'menu_show'         => 1,
+					'show_page_heading' => 0,
+					'secure'            => 0,
 				),
 			),
 		);


### PR DESCRIPTION

### Summary of Changes
Show only article title (h2) in articles. This avoids the "double" headlines in singele articles, if menu item and article are the same or similiar.


