### PR TITLE
Resolve overlapping text in menu item

### DIFF
--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -41,10 +41,6 @@
           padding: .375em 1em;
           list-style: none;
           box-shadow: 0 0 10px hsla(0, 0%, 0%, .1);
-
-          @include media-breakpoint-down(md) {
-            width: 100%;
-          }
         }
         > span,
         > a {
@@ -180,6 +176,16 @@
           top: 0;
           padding: 0 1em;
           box-shadow: none;
+
+          @include media-breakpoint-down(md) {
+            width: 100%;
+          }
+        }
+      }
+      .metismenu-item {
+        > span,
+        > a {
+          white-space: inherit;
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue #252 .

### Summary of Changes
Change width of submenu in small displays
Remove white-space:nowrap on sidebar menus


### Testing Instructions
npm run build:css


### Expected result
Submenus with long menu items will adapt to the length of text
Long menu items will break on sidebars


### Actual result
See screenshot in issue


### Documentation Changes Required

