### PR TITLE
add border around back to top && add transition on mouseover

### DIFF
--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -36,5 +36,6 @@ $scrollLength: 100vh;
   &:focus {
     color: var(--white, $white);
     background-color: var(--cassiopeia-color-hover);
+    border-color: var(--white, $white);
   }
 }

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -7,14 +7,14 @@ $scrollLength: 100vh;
 .back-to-top-wrapper {
   position: absolute;
   top: calc(#{$scrollLength} + #{$cassiopeia-grid-gutter * 10});
-  right: $cassiopeia-grid-gutter;
+  right: 0;
   bottom: 0;
   width: 3rem;
   pointer-events: none;
 
   [dir=rtl] & {
     right: unset;
-    left: $cassiopeia-grid-gutter;
+    left: 0;
   }
 }
 
@@ -27,13 +27,13 @@ $scrollLength: 100vh;
   color: var(--cassiopeia-color-primary, $standard-color-primary);
   pointer-events: all;
   background-color: var(--white, $white);
-  border: 1px solid transparent;
+  border: 1px solid var(--cassiopeia-color-primary, $standard-color-primary);
   border-radius: $border-radius;
-  transition: border-color 200ms ease-in;
+  transition: all 200ms ease-in;
 
   &:hover,
   &:focus {
-    color: var(--cassiopeia-color-hover);
-    border-color: var(--cassiopeia-color-primary, $standard-color-primary);
+    color: var(--white, $white);
+    background-color: var(--cassiopeia-color-hover);
   }
 }

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -23,7 +23,7 @@ $scrollLength: 100vh;
   position: fixed;
   /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
   position: sticky;
-  top: calc(#{$scrollLength} - #{$cassiopeia-grid-gutter * 3});
+  top: calc(#{$scrollLength} - #{$cassiopeia-grid-gutter * 4});
   padding: $cassiopeia-grid-gutter/2;
   color: var(--cassiopeia-color-primary, $standard-color-primary);
   pointer-events: all;

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -9,6 +9,7 @@ $scrollLength: 100vh;
   top: calc(#{$scrollLength} + #{$cassiopeia-grid-gutter * 10});
   right: 0;
   bottom: 0;
+  z-index: $zindex-fixed;
   width: 3rem;
   pointer-events: none;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/31520

### Summary of Changes
fixing both comments
- https://github.com/joomla/joomla-cms/pull/31520#issuecomment-735431121
- https://github.com/joomla/joomla-cms/pull/31520#issuecomment-735431775

### Testing Instructions

- apply patch 31520
- `npm run build:css`
- activate back-to-top in template settings
- visit homepage and scroll to see the back-to-top

### Actual result BEFORE applying this Pull Request

see comment made by @brianteeman 

### Expected result AFTER applying this Pull Request

#### changed z-index
![Schermafbeelding 2020-11-30 om 12 10 23](https://user-images.githubusercontent.com/639822/100603436-69ee2580-3305-11eb-8de1-e733d4898162.png)


#### normal state 
![Schermafbeelding 2020-11-30 om 12 11 29](https://user-images.githubusercontent.com/639822/100603439-6b1f5280-3305-11eb-91cd-16d61887057c.png)


#### hover state
![Schermafbeelding 2020-11-30 om 12 11 14](https://user-images.githubusercontent.com/639822/100603437-6a86bc00-3305-11eb-9b55-cf5cbbd1978a.png)
![Schermafbeelding 2020-11-30 om 12 11 24](https://user-images.githubusercontent.com/639822/100603438-6b1f5280-3305-11eb-9777-a5dd3c394575.png)


### Documentation Changes Required

