### PR TITLE
Color fixes metismenu

### DIFF
--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -8,6 +8,7 @@
 
   .banner-overlay {
     height: 70vh;
+    color: $white;
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-position: top,center;

--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -1,8 +1,6 @@
 // Banner
 
 .container-banner {
-  color: $white;
-
   img {
     display: block;
     margin: auto;

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -160,6 +160,12 @@
           transform: rotateX(-180deg);
         }
       }
+
+      .parent {
+        > ul {
+          color: $gray-900;
+        }
+      }
     }
   }
 

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -49,7 +49,8 @@
         }
 
         > span,
-        > a {
+        > a,
+        > button {
           overflow: hidden;
           text-decoration: none;
           text-overflow: ellipsis;
@@ -128,11 +129,9 @@
         position: relative;
         display: flex;
         align-items: center;
-        justify-content: center;
         height: 100%;
         padding: 0;
         color: currentColor;
-        white-space: nowrap;
         user-select: none;
         background: none;
         border: none;

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -132,6 +132,7 @@
         height: 100%;
         padding: 0;
         color: currentColor;
+        white-space: nowrap;
         user-select: none;
         background: none;
         border: none;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

mentioned in https://github.com/joomla/joomla-cms/pull/31520#issuecomment-736108234

> . The button `.metismenu.mod-menu .mm-toggler` has a class of `color: currentColor;` which appears to be white, which in the banner position, renders it invisible.

fixing color on container-banner

<img width="368" alt="Schermafbeelding 2020-12-01 om 07 37 01" src="https://user-images.githubusercontent.com/639822/100705943-5f389c80-33a8-11eb-9b9c-91de16707e4b.png">


> > 1. Some of the items wrap text; others don't

<img width="1405" alt="Schermafbeelding 2020-12-01 om 07 58 34" src="https://user-images.githubusercontent.com/639822/100707478-08809200-33ab-11eb-91a9-a4022ebe099c.png">

This PR fixes whitespace wrap in span anchor and button element. This PR does not fix white space wrap inside li element
