### PR TITLE
change copyright year from 2019 to 2020

### DIFF
--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Templates.cassiopeia
  *
- * @copyright   (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
fixes copyright year 2019 in html/layouts/chrome/card