### PR TITLE
Add another styling for menu separator not parent

### DIFF
--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -83,6 +83,14 @@
             margin-left: -1em;
           }
         }
+
+        &.divider:not(.parent) {
+          width: 1px;
+          padding: 0;
+          margin: .25em;
+          overflow: hidden;
+          border-right: 1px solid $gray-400;
+        }
       }
 
       .mm-collapsing {
@@ -105,6 +113,12 @@
         > li {
           > a {
             display: inline-flex;
+          }
+
+          &.divider:not(.parent) {
+            width: auto;
+            height: 1px;
+            border-bottom: 1px solid $gray-400;
           }
         }
 
@@ -202,6 +216,12 @@
         > span,
         > a {
           white-space: inherit;
+        }
+
+        &.divider:not(.parent) {
+          width: auto;
+          height: 1px;
+          border-bottom: 1px solid $gray-400;
         }
       }
     }

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -90,6 +90,13 @@
           margin: .25em;
           overflow: hidden;
           border-right: 1px solid $gray-400;
+
+          @include media-breakpoint-down(sm) {
+            width: auto;
+            height: 1px;
+            border-bottom: 1px solid $gray-400;
+          }
+
         }
       }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add styling for menu separator that is not parent


### Testing Instructions
npm run build:css

Check 

- a separator item that is not parent on top level in the navbar and on the sidebar

- a separator item that is not a parent in a submenu


### Actual result BEFORE applying this Pull Request
You see text


### Expected result AFTER applying this Pull Request
You see a line instead of text

![grafik](https://user-images.githubusercontent.com/9153168/100746561-2668e980-33e1-11eb-88e1-6863ce5e2240.png)
![grafik](https://user-images.githubusercontent.com/9153168/100746509-16e9a080-33e1-11eb-800a-1bb7e1290e02.png)

